### PR TITLE
Fix error handling in playlist suggestions

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -643,11 +643,10 @@ async def suggest_from_analyzed(request: Request):
             "Average_BPM": int(summary['tempo_avg']),
             "Popularity": int(summary['avg_popularity']),
             "Decades": summary['decades'].keys(),
-            "playlist_name": playlist_name,
         })
     except Exception as e:
-        logger.error(f"Error in /suggest: {e}", exc_info=True)
-        return
+        logger.error(f"Error in /suggest-playlist: {e}", exc_info=True)
+        return JSONResponse({"error": str(e)}, status_code=500)
 
 @router.post("/history/bulk-delete", response_class=HTMLResponse)
 async def bulk_delete_history(request: Request):


### PR DESCRIPTION
## Summary
- fix `suggest_from_analyzed` error path returning `None`
- remove duplicate `playlist_name` entry in the template response

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6876d7ac2da8833284ad5cc2930adced