### PR TITLE
Fix extra </head> in base template

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -7,7 +7,6 @@
   <link rel="stylesheet" href="/static/style.css">
 <script src="https://cdn.tailwindcss.com"></script>
 </head>
-</head>
 <body class="bg-gray-100 text-gray-900 dark:bg-gray-900 dark:text-gray-100">
 {% import "macros.html" as macros %}
   <header class="site-header">


### PR DESCRIPTION
## Summary
- remove duplicate closing `</head>` tag from base template so the HTML head is properly closed once

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876deccc2b88332bba281145857e195