### PR TITLE
Refactor repeated history/playlist loading

### DIFF
--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -1,0 +1,23 @@
+from core.playlist import fetch_audio_playlists
+from core.history import load_user_history, extract_date_from_label
+from utils.cache_manager import playlist_cache, CACHE_TTLS
+from config import settings
+
+
+def get_cached_playlists(user_id: str | None = None) -> dict:
+    """Return audio playlists for a user using caching."""
+    user_id = user_id or settings.jellyfin_user_id
+    cache_key = f"playlists:{user_id}"
+    playlists_data = playlist_cache.get(cache_key)
+    if playlists_data is None:
+        playlists_data = fetch_audio_playlists()
+        playlist_cache.set(cache_key, playlists_data, expire=CACHE_TTLS["playlists"])
+    return playlists_data
+
+
+def load_sorted_history(user_id: str | None = None) -> list:
+    """Load user history sorted by most recent entries."""
+    user_id = user_id or settings.jellyfin_user_id
+    history = load_user_history(user_id)
+    history.sort(key=lambda e: extract_date_from_label(e["label"]), reverse=True)
+    return history


### PR DESCRIPTION
## Summary
- add helper utilities for cached playlist retrieval and sorted history
- refactor routes to reuse new helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876f33c1854833284e6aa0f8e83b41c