### PR TITLE
Use async OpenAI client in GPT service

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -626,7 +626,7 @@ async def analyze_selected_playlist(  # pylint: disable=too-many-locals
     base_summary = summarize_tracks(enriched)
     summary.update(base_summary)
 
-    gpt_summary, removal_suggestions = generate_playlist_analysis_summary(summary, enriched)
+    gpt_summary, removal_suggestions = await generate_playlist_analysis_summary(summary, enriched)
 
     return templates.TemplateResponse("analysis_result.html", {
         "request": request,


### PR DESCRIPTION
## Summary
- instantiate both synchronous and asynchronous OpenAI clients
- provide async `cached_chat_completion` while keeping a sync variant for legacy callers
- update GPT playlist summary generation to use `AsyncOpenAI`
- await summary generation in routes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687993445e88833281b7f88a9140e7ff