### PR TITLE
Parallelize playlist enrichment

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -546,7 +546,7 @@ async def analyze_selected_playlist(  # pylint: disable=too-many-locals
 ):
     """Analyze a selected playlist from Jellyfin or GPT history."""
     if source_type == "jellyfin":
-        enriched = enrich_jellyfin_playlist(playlist_id)
+        enriched = await enrich_jellyfin_playlist(playlist_id)
         name_data = get_cached_playlists(settings.jellyfin_user_id)
         playlistdetail = name_data.get("playlists", [])
         playlist_name = "Temporary Name"


### PR DESCRIPTION
## Summary
- update playlist enrichment to run track processing in parallel
- call new async playlist enrichment function from the API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687990f9ac688332a435b86ac7a8f814