### PR TITLE
Switch HTTP calls to async

### DIFF
--- a/core/m3u.py
+++ b/core/m3u.py
@@ -116,7 +116,7 @@ def infer_track_metadata_from_path(path):
     return {"title": title, "artist": artist}
 
 
-def import_m3u_as_history_entry(filepath: str):
+async def import_m3u_as_history_entry(filepath: str):
     logger.info(f"📂 Importing M3U playlist: {filepath}")
     user_id=settings.jellyfin_user_id
     imported_tracks = []
@@ -127,10 +127,10 @@ def import_m3u_as_history_entry(filepath: str):
         meta = infer_track_metadata_from_path(path)
         title = meta['title']
         artist = meta['artist']
-        result = search_jellyfin_for_track(title, artist)
+        result = await search_jellyfin_for_track(title, artist)
         if result:
             track_dict = {"title": title, "artist": artist}
-            enriched = enrich_track(track_dict) or track_dict   # fallback to base if enrich returns None
+            enriched = await enrich_track(track_dict) or track_dict   # fallback to base if enrich returns None
             enriched.setdefault('text', f"{title} - {artist}")
             enriched.setdefault('reason', "Imported from M3U file.")
             enriched.setdefault('youtube_url', f"https://www.youtube.com/results?search_query={title}+{artist}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ uvicorn
 yt-dlp
 python-multipart
 cloudscraper
+httpx

--- a/services/gpt.py
+++ b/services/gpt.py
@@ -7,7 +7,6 @@ Handles GPT prompt generation, caching, and result validation for playlist sugge
 import hashlib
 import logging
 import asyncio
-import requests
 import os
 import json
 from typing import Tuple

--- a/tests/test_m3u.py
+++ b/tests/test_m3u.py
@@ -7,10 +7,14 @@ import types
 sys.modules.setdefault('httpx', types.ModuleType('httpx'))
 services_stub = types.ModuleType('services.jellyfin')
 services_stub.resolve_jellyfin_path = lambda *a, **kw: None
-services_stub.search_jellyfin_for_track = lambda *a, **kw: None
+async def _dummy_search(*a, **kw):
+    return None
+services_stub.search_jellyfin_for_track = _dummy_search
 sys.modules.setdefault('services.jellyfin', services_stub)
 playlist_stub = types.ModuleType('core.playlist')
-playlist_stub.enrich_track = lambda *a, **kw: {}
+async def _dummy_enrich(*a, **kw):
+    return {}
+playlist_stub.enrich_track = _dummy_enrich
 sys.modules.setdefault('core.playlist', playlist_stub)
 
 from core.m3u import parse_track_text, infer_track_metadata_from_path

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -4,13 +4,13 @@ from utils.cache_manager import playlist_cache, CACHE_TTLS
 from config import settings
 
 
-def get_cached_playlists(user_id: str | None = None) -> dict:
+async def get_cached_playlists(user_id: str | None = None) -> dict:
     """Return audio playlists for a user using caching."""
     user_id = user_id or settings.jellyfin_user_id
     cache_key = f"playlists:{user_id}"
     playlists_data = playlist_cache.get(cache_key)
     if playlists_data is None:
-        playlists_data = fetch_audio_playlists()
+        playlists_data = await fetch_audio_playlists()
         playlist_cache.set(cache_key, playlists_data, expire=CACHE_TTLS["playlists"])
     return playlists_data
 


### PR DESCRIPTION
## Summary
- use `httpx.AsyncClient` across the project
- update Jellyfin and Last.fm services to async
- convert playlist helpers to await async services
- adapt API routes and utilities for async calls
- add `httpx` dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68799588b3108332a066d57d847c9ead