### PR TITLE
Introduce typed track models with Pydantic

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -142,7 +142,7 @@ async def enrich_suggestion(suggestion):
             "artist": suggestion["artist"],
             "jellyfin_play_count": play_count,
             "Genres": genres,
-            "RunTimeTicks": duration_ticks
+            "RunTimeTicks": duration_ticks,
         }
         enriched = await enrich_track(parsed)
         return {
@@ -152,7 +152,7 @@ async def enrich_suggestion(suggestion):
             "artist": suggestion["artist"],
             "youtube_url": youtube_url,
             "in_jellyfin": in_jellyfin,
-            **enriched
+            **enriched.dict()
         }
 
     except Exception as e:  # pylint: disable=broad-exception-caught
@@ -648,7 +648,10 @@ async def analyze_selected_playlist(  # pylint: disable=too-many-locals
         clean_label = label_parts[0].strip() if len(label_parts) > 1 else entry.get("label")
         playlist_name = f"{clean_label} Suggestions"
         start = perf_counter()
-        enriched = [enrich_track(normalize_track(t)) for t in tracks]
+        enriched = []
+        for t in tracks:
+            res = await enrich_track(normalize_track(t))
+            enriched.append(res.dict())
         logger.debug("Enriched Tracks: %.2fs", perf_counter() - start)
     start = perf_counter()
     parsed_enriched = [s for s in enriched if s is not None]

--- a/core/m3u.py
+++ b/core/m3u.py
@@ -138,7 +138,8 @@ async def import_m3u_as_history_entry(filepath: str):
         artist = meta['artist']
         if result:
             track_dict = {"title": title, "artist": artist}
-            enriched = await enrich_track(track_dict) or track_dict   # fallback to base if enrich returns None
+            enriched_obj = await enrich_track(track_dict)
+            enriched = enriched_obj.dict() if enriched_obj else track_dict   # fallback to base if enrich returns None
             enriched.setdefault('text', f"{title} - {artist}")
             enriched.setdefault('reason', "Imported from M3U file.")
             enriched.setdefault('youtube_url', f"https://www.youtube.com/results?search_query={title}+{artist}")

--- a/core/models.py
+++ b/core/models.py
@@ -1,0 +1,36 @@
+from pydantic import BaseModel, Field
+from typing import List, Optional
+
+class Track(BaseModel):
+    """Normalized track metadata."""
+
+    raw: str = ""
+    title: str
+    artist: str
+    album: str = ""
+    year: str = ""
+    Genres: List[str] = Field(default_factory=list)
+    lyrics: Optional[str] = None
+    tempo: Optional[int] = None
+    RunTimeTicks: int = 0
+    jellyfin_play_count: int = 0
+
+    class Config:
+        extra = "allow"
+
+class EnrichedTrack(Track):
+    """Track metadata after enrichment."""
+
+    tags: List[str] = Field(default_factory=list)
+    genre: str = "Unknown"
+    mood: str = "Unknown"
+    mood_confidence: float = 0.0
+    decade: str = "Unknown"
+    duration: int = 0
+    popularity: int = 0
+    year_flag: str = ""
+    combined_popularity: Optional[float] = None
+    FinalYear: Optional[str] = None
+
+    class Config:
+        extra = "allow"


### PR DESCRIPTION
## Summary
- add `Track` and `EnrichedTrack` models
- return typed objects from `normalize_track` and `enrich_track`
- update playlist enrichment logic to use new models
- adjust API routes and M3U import to convert from models

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a16ca6b108332bea7595f6b28d1e1