### PR TITLE
Fix remaining pylint warnings

### DIFF
--- a/services/gpt.py
+++ b/services/gpt.py
@@ -256,9 +256,10 @@ async def generate_playlist_analysis_summary(summary: dict, tracks: list):
     # Return from cache if available
     if cache_key in prompt_cache:
         logger.info("Prompt Cache Hit in generate_playlist_analysis_summary")
+        cached = prompt_cache[cache_key]
         return (
-            prompt_cache[cache_key]["gpt_summary"],
-            prompt_cache[cache_key]["removal_suggestions"],
+            cached["gpt_summary"],
+            cached["removal_suggestions"],
         )
 
     logger.info("Prompt Cache Miss generate_playlist_analysis_summary")

--- a/tests/test_m3u.py
+++ b/tests/test_m3u.py
@@ -1,18 +1,21 @@
+"""Unit tests for M3U parsing utilities."""
+
 import os
 import sys
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import types
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 # Stub optional dependencies to allow importing core.m3u without installing them
 sys.modules.setdefault('httpx', types.ModuleType('httpx'))
 services_stub = types.ModuleType('services.jellyfin')
-services_stub.resolve_jellyfin_path = lambda *a, **kw: None
-async def _dummy_search(*a, **kw):
+services_stub.resolve_jellyfin_path = lambda *_a, **_kw: None
+async def _dummy_search(*_a, **_kw):
     return None
 services_stub.search_jellyfin_for_track = _dummy_search
 sys.modules.setdefault('services.jellyfin', services_stub)
 playlist_stub = types.ModuleType('core.playlist')
-async def _dummy_enrich(*a, **kw):
+async def _dummy_enrich(*_a, **_kw):
     return {}
 playlist_stub.enrich_track = _dummy_enrich
 sys.modules.setdefault('core.playlist', playlist_stub)
@@ -21,38 +24,45 @@ from core.m3u import parse_track_text, infer_track_metadata_from_path
 
 
 def test_parse_track_text_basic():
+    """Parse artist and title separated by dash."""
     artist, title = parse_track_text("Queen - Bohemian Rhapsody")
     assert artist == "Queen"
     assert title == "Bohemian Rhapsody"
 
 
 def test_parse_track_text_fallback():
+    """Fallback to Unknown when only title is provided."""
     artist, title = parse_track_text("Bohemian Rhapsody")
     assert artist == "Unknown"
     assert title == "Bohemian Rhapsody"
 
 
 def test_parse_track_text_extra_parts():
+    """Handle extra segments after artist and title."""
     artist, title = parse_track_text("Metallica - One - Live")
     assert artist == "Metallica"
     assert title == "One"
 
 
 def test_infer_metadata_artist_title():
+    """Infer metadata from artist-title filename."""
     meta = infer_track_metadata_from_path("Music/Metallica/Justice/Metallica - One.mp3")
     assert meta == {"title": "One", "artist": "Metallica"}
 
 
 def test_infer_metadata_numbered_track():
+    """Handle tracks with numeric prefix."""
     meta = infer_track_metadata_from_path("Music/Metallica/Justice/01 - One.mp3")
     assert meta == {"title": "One", "artist": "Metallica"}
 
 
 def test_infer_metadata_simple_title():
+    """Infer metadata when only title present."""
     meta = infer_track_metadata_from_path("Music/Metallica/Justice/One.mp3")
     assert meta == {"title": "One", "artist": "Metallica"}
 
 
 def test_infer_metadata_windows_path():
+    """Support Windows path separators."""
     meta = infer_track_metadata_from_path(r"C:\\Music\\Metallica\\Justice\\Metallica - One.mp3")
     assert meta == {"title": "One", "artist": "Metallica"}

--- a/utils/cache_manager.py
+++ b/utils/cache_manager.py
@@ -11,8 +11,8 @@ Defines named persistent caches using diskcache for various subsystems:
 All caches are file-backed and located in the `cache/` directory.
 """
 
-from diskcache import Cache
 from pathlib import Path
+from diskcache import Cache
 
 # Root directory for all cache files
 BASE_CACHE = Path("cache")

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -1,3 +1,5 @@
+"""Helper functions for cached playlist retrieval and history sorting."""
+
 from core.playlist import fetch_audio_playlists
 from core.history import load_user_history, extract_date_from_label
 from utils.cache_manager import playlist_cache, CACHE_TTLS


### PR DESCRIPTION
## Summary
- fix invalid index access in GPT cache
- clean up Jellyfin service logging and line length issues
- standardize import order and lazy logging in Last.fm and MeTube services
- add module and function docstrings for helper utilities and tests
- tidy cache manager import order

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b58ef243c83328e37b8b0512257f9