### PR TITLE
Centralize additional settings

### DIFF
--- a/config.py
+++ b/config.py
@@ -46,6 +46,39 @@ class AppSettings(BaseModel):
     lastfm_api_key: str = ""
     model: str = "gpt-4o-mini"
     getsongbpm_api_key: str = ""
+    global_min_lfm: int = 10_000
+    global_max_lfm: int = 15_000_000
+    cache_ttls: dict[str, int] = {
+        "prompt": 60 * 60 * 24,
+        "youtube": 60 * 60 * 6,
+        "lastfm": 60 * 60 * 24 * 7,
+        "lastfm_popularity": 60 * 60 * 24 * 7,
+        "playlists": 60 * 30,
+        "bpm": 60 * 60 * 24 * 30,
+        "jellyfin_tracks": 60 * 60 * 24,
+        "full_library": 60 * 60 * 24,
+    }
+    getsongbpm_base_url: str = "https://api.getsongbpm.com/search/"
+    getsongbpm_headers: dict[str, str] = {
+        "User-Agent": (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/124.0.0.0 Safari/537.36"
+        ),
+        "Accept": "application/json, text/javascript, */*; q=0.01",
+        "Referer": "https://getsongbpm.com/",
+        "Accept-Language": "en-US,en;q=0.9",
+        "X-Requested-With": "XMLHttpRequest",
+    }
+    http_timeout_short: int = 5
+    http_timeout_long: int = 10
+    youtube_min_duration: int = 120
+    youtube_max_duration: int = 360
+    library_scan_limit: int = 1000
+    music_library_root: str = "Movies/Music"
+    lyrics_weight: float = 1.5
+    bpm_weight: float = 1.0
+    tags_weight: float = 0.7
 
     def validate_settings(self) -> None:
         """
@@ -100,5 +133,5 @@ def save_settings(s: AppSettings) -> None:
 settings: AppSettings = load_settings()
 logging.getLogger("playlist-pilot").debug("settings loaded: %s", settings.dict())
 
-GLOBAL_MIN_LFM = 10_000        # anything below this is "low popularity"
-GLOBAL_MAX_LFM = 15_000_000     # extremely popular tracks
+GLOBAL_MIN_LFM = settings.global_min_lfm
+GLOBAL_MAX_LFM = settings.global_max_lfm

--- a/core/analysis.py
+++ b/core/analysis.py
@@ -6,6 +6,7 @@ from statistics import mean
 import math
 import logging
 import re
+from config import settings
 
 logger = logging.getLogger("playlist-pilot")
 
@@ -341,9 +342,9 @@ MOOD_WEIGHTS = {
 }
 
 
-LYRICS_WEIGHT = 1.5  # Tunable weight for lyrics signal (can make configurable)
-BPM_WEIGHT = 1
-TAGS_WEIGHT = 0.7
+LYRICS_WEIGHT = settings.lyrics_weight
+BPM_WEIGHT = settings.bpm_weight
+TAGS_WEIGHT = settings.tags_weight
 DEFAULT_LYRICS_CONFIDENCE = 1  # Confidence assigned to GPT-derived mood
 
 MOOD_MAPPING = {

--- a/core/m3u.py
+++ b/core/m3u.py
@@ -23,7 +23,7 @@ def generate_proposed_path(artist: str, album: str, title: str) -> str:
     artist_dir = artist.strip()
     album_dir = album.strip() if album else "Unknown Album"
     title_file = title.strip()
-    return f"Movies/Music/{artist_dir}/{album_dir}/{title_file}.mp3"
+    return f"{settings.music_library_root}/{artist_dir}/{album_dir}/{title_file}.mp3"
 
 def parse_track_text(text: str) -> tuple[str, str]:
     """Split a track label into artist and title parts."""

--- a/core/playlist.py
+++ b/core/playlist.py
@@ -111,7 +111,7 @@ async def get_full_audio_library(force_refresh: bool = False) -> list[str]:
 
     items: list[str] = []
     start_index = 0
-    limit = 1000
+    limit = settings.library_scan_limit
     while True:
         response = await jf_get(
             f"/Users/{settings.jellyfin_user_id}/Items",

--- a/services/getsongbpm.py
+++ b/services/getsongbpm.py
@@ -7,6 +7,7 @@ from typing import Optional, Dict
 import cloudscraper
 
 from utils.cache_manager import bpm_cache, CACHE_TTLS
+from config import settings
 
 logger = logging.getLogger("playlist-pilot")
 
@@ -15,27 +16,20 @@ def get_bpm_from_getsongbpm(
 ) -> Optional[Dict[str, Optional[int]]]:
     """Query GetSongBPM for tempo and related metadata."""
     lookup = quote_plus(f"song:{title} artist:{artist}")
-    base_url = "https://api.getsongbpm.com/search/"
     search_url = (
-        f"{base_url}?api_key={api_key}&type=both&lookup={lookup}"
+        f"{settings.getsongbpm_base_url}?api_key={api_key}&type=both&lookup={lookup}"
     )
 
-    headers = {
-        "User-Agent": (
-            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-            "AppleWebKit/537.36 (KHTML, like Gecko) "
-            "Chrome/124.0.0.0 Safari/537.36"
-        ),
-        "Accept": "application/json, text/javascript, */*; q=0.01",
-        "Referer": "https://getsongbpm.com/",
-        "Accept-Language": "en-US,en;q=0.9",
-        "X-Requested-With": "XMLHttpRequest",
-    }
+    headers = settings.getsongbpm_headers
 
     try:
         data = (
             cloudscraper.create_scraper(browser="chrome")
-            .get(search_url, headers=headers, timeout=5)
+            .get(
+                search_url,
+                headers=headers,
+                timeout=settings.http_timeout_short,
+            )
             .json()
         )
     except Exception as exc:  # pylint: disable=broad-exception-caught

--- a/services/gpt.py
+++ b/services/gpt.py
@@ -290,7 +290,7 @@ async def generate_playlist_analysis_summary(summary: dict, tracks: list):
     )
 
     response = await async_openai_client.chat.completions.create(
-        model="gpt-4",
+        model=settings.model,
         messages=[{"role": "user", "content": prompt}],
         temperature=0.7,
     )

--- a/services/jellyfin.py
+++ b/services/jellyfin.py
@@ -23,7 +23,11 @@ async def fetch_jellyfin_users():
         url = f"{settings.jellyfin_url.rstrip('/')}/Users"
         headers = {"X-Emby-Token": settings.jellyfin_api_key}
         async with httpx.AsyncClient() as client:
-            resp = await client.get(url, headers=headers, timeout=10)
+            resp = await client.get(
+                url,
+                headers=headers,
+                timeout=settings.http_timeout_long,
+            )
         resp.raise_for_status()
         return {u["Name"]: u["Id"] for u in resp.json()}
     except Exception as exc:  # pylint: disable=broad-exception-caught
@@ -50,7 +54,7 @@ async def search_jellyfin_for_track(title: str, artist: str) -> bool:
                     "api_key": settings.jellyfin_api_key,
                     "userId": settings.jellyfin_user_id,
                 },
-                timeout=10,
+                timeout=settings.http_timeout_long,
             )
         response.raise_for_status()
         data = response.json()
@@ -111,7 +115,11 @@ async def fetch_tracks_for_playlist_id(playlist_id: str) -> list[dict]:
 
     try:
         async with httpx.AsyncClient() as client:
-            response = await client.get(url, params=params, timeout=10)
+            response = await client.get(
+                url,
+                params=params,
+                timeout=settings.http_timeout_long,
+            )
         response.raise_for_status()
         data = response.json()
         items = data.get("Items", [])
@@ -140,7 +148,11 @@ async def fetch_lyrics_for_item(item_id: str) -> str:
     params = {"api_key": settings.jellyfin_api_key}
     try:
         async with httpx.AsyncClient() as client:
-            response = await client.get(url, params=params, timeout=5)
+            response = await client.get(
+                url,
+                params=params,
+                timeout=settings.http_timeout_short,
+            )
         if response.status_code == 200 and response.text.strip():
             logger.info("Fetched raw lyrics JSON from Jellyfin for item %s", item_id)
             return response.text.strip()
@@ -219,7 +231,7 @@ async def fetch_jellyfin_track_metadata(title: str, artist: str) -> dict | None:
                     "api_key": settings.jellyfin_api_key,
                     "userId": settings.jellyfin_user_id,
                 },
-                timeout=10,
+                timeout=settings.http_timeout_long,
             )
         response.raise_for_status()
         data = response.json()
@@ -272,7 +284,12 @@ async def resolve_jellyfin_path(title: str, artist: str, jellyfin_url: str, jell
 
     async with httpx.AsyncClient() as client:
         try:
-            resp = await client.get(url, headers=headers, params=params, timeout=10)
+            resp = await client.get(
+                url,
+                headers=headers,
+                params=params,
+                timeout=settings.http_timeout_long,
+            )
             resp.raise_for_status()
 
             data = resp.json()
@@ -335,7 +352,12 @@ async def create_jellyfin_playlist(
 
     try:
         async with httpx.AsyncClient() as client:
-            response = await client.post(url, headers=headers, json=payload, timeout=10)
+            response = await client.post(
+                url,
+                headers=headers,
+                json=payload,
+                timeout=settings.http_timeout_long,
+            )
         response.raise_for_status()
         playlist_id = response.json().get("Id")
         logger.info("✅ Jellyfin playlist created with Id: %s", playlist_id)
@@ -351,7 +373,11 @@ async def get_full_item(item_id: str) -> dict | None:
     headers = {"X-Emby-Token": settings.jellyfin_api_key}
     try:
         async with httpx.AsyncClient() as client:
-            resp = await client.get(url, headers=headers, timeout=10)
+            resp = await client.get(
+                url,
+                headers=headers,
+                timeout=settings.http_timeout_long,
+            )
         resp.raise_for_status()
         return resp.json()
     except Exception as exc:  # pylint: disable=broad-exception-caught
@@ -365,7 +391,12 @@ async def update_item_metadata(item_id: str, full_item: dict) -> bool:
     logger.info("Updating Item Metadata - Url:%s", url)
     try:
         async with httpx.AsyncClient() as client:
-            resp = await client.post(url, headers=headers, json=full_item, timeout=10)
+            resp = await client.post(
+                url,
+                headers=headers,
+                json=full_item,
+                timeout=settings.http_timeout_long,
+            )
         resp.raise_for_status()
         logger.info("✅ Successfully updated Jellyfin item %s", item_id)
         return True

--- a/services/lastfm.py
+++ b/services/lastfm.py
@@ -46,7 +46,7 @@ async def get_lastfm_tags(title: str, artist: str) -> list[str]:
                     "track": title,
                     "format": "json",
                 },
-                timeout=5,
+                timeout=settings.http_timeout_short,
             )
         response.raise_for_status()
         data = response.json()
@@ -83,7 +83,7 @@ async def get_lastfm_track_info(title: str, artist: str) -> dict | None:
                     "track": title,
                     "format": "json",
                 },
-                timeout=10,
+                timeout=settings.http_timeout_long,
             )
         response.raise_for_status()
         data = response.json()

--- a/services/metube.py
+++ b/services/metube.py
@@ -12,6 +12,7 @@ from urllib.parse import quote_plus
 import yt_dlp
 from core.playlist import build_search_query, clean
 from utils.cache_manager import yt_search_cache, CACHE_TTLS
+from config import settings
 
 logger = logging.getLogger("playlist-pilot")
 
@@ -55,8 +56,11 @@ async def get_youtube_url_single(search_line: str) -> tuple[str, str | None]:
 
         ref = clean(search_term)
         filtered_entries = [
-            e for e in entries
-            if 120 <= e.get("duration", 0) <= 360
+            e
+            for e in entries
+            if settings.youtube_min_duration
+            <= e.get("duration", 0)
+            <= settings.youtube_max_duration
         ]
 
         best_match = None

--- a/utils/cache_manager.py
+++ b/utils/cache_manager.py
@@ -13,6 +13,7 @@ All caches are file-backed and located in the `cache/` directory.
 
 from pathlib import Path
 from diskcache import Cache
+from config import settings
 
 # Root directory for all cache files
 BASE_CACHE = Path("cache")
@@ -46,13 +47,4 @@ library_cache = Cache(BASE_CACHE / "full_library")
 
 
 # TTL configuration (in seconds) for each named cache
-CACHE_TTLS = {
-    "prompt": 60 * 60 * 24,            # 24 hours
-    "youtube": 60 * 60 * 6,            # 6 hours
-    "lastfm": 60 * 60 * 24 * 7,        # 7 days
-    "lastfm_popularity": 60 * 60 * 24 * 7,
-    "playlists": 60 * 30,              # 30 minutes
-    "bpm": 60 * 60 * 24 * 30,          # 30-day TTL
-    "jellyfin_tracks": 60 * 60 * 24,   # 24 hours
-    "full_library": 60 * 60 * 24       # 24 hours
-}
+CACHE_TTLS = settings.cache_ttls


### PR DESCRIPTION
## Summary
- expand `AppSettings` with more configurable values
- update modules to reference the new settings
- replace hard-coded API model, timeouts and durations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bb5dc5f188332b78b9a83c81b5aa1