### PR TITLE
Standardize settings file path

### DIFF
--- a/core/constants.py
+++ b/core/constants.py
@@ -6,7 +6,8 @@ from pathlib import Path
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 USER_DATA_DIR = BASE_DIR / "user_data"
-SETTINGS_FILE = BASE_DIR / "settings.json"
+# Match the location used in `config.py` so settings are read from the same file
+SETTINGS_FILE = Path("/app/settings.json")
 CACHE_DIR = BASE_DIR / "cache"
 LOG_FILE = BASE_DIR / "logs" / "playlist_pilot.log"
 


### PR DESCRIPTION
## Summary
- point `core.constants.SETTINGS_FILE` at the same location as `config.SETTINGS_FILE`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687bbf805f4c83328eb05e84c7787ea5