### PR TITLE
Expose more settings in UI

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -98,6 +98,20 @@ class SettingsForm(AppSettings):
         lastfm_api_key: str = Form(""),
         model: str = Form("gpt-4o-mini"),
         getsongbpm_api_key: str = Form(""),
+        global_min_lfm: int = Form(10000),
+        global_max_lfm: int = Form(15000000),
+        cache_ttls: str = Form(""),
+        getsongbpm_base_url: str = Form("https://api.getsongbpm.com/search/"),
+        getsongbpm_headers: str = Form(""),
+        http_timeout_short: int = Form(5),
+        http_timeout_long: int = Form(10),
+        youtube_min_duration: int = Form(120),
+        youtube_max_duration: int = Form(360),
+        library_scan_limit: int = Form(1000),
+        music_library_root: str = Form("Movies/Music"),
+        lyrics_weight: float = Form(1.5),
+        bpm_weight: float = Form(1.0),
+        tags_weight: float = Form(0.7),
     ) -> "SettingsForm":
         """Create a SettingsForm instance from submitted form data."""
         return cls(
@@ -108,6 +122,20 @@ class SettingsForm(AppSettings):
             lastfm_api_key=lastfm_api_key,
             model=model,
             getsongbpm_api_key=getsongbpm_api_key,
+            global_min_lfm=global_min_lfm,
+            global_max_lfm=global_max_lfm,
+            cache_ttls=json.loads(cache_ttls) if cache_ttls else AppSettings().cache_ttls,
+            getsongbpm_base_url=getsongbpm_base_url,
+            getsongbpm_headers=json.loads(getsongbpm_headers) if getsongbpm_headers else AppSettings().getsongbpm_headers,
+            http_timeout_short=http_timeout_short,
+            http_timeout_long=http_timeout_long,
+            youtube_min_duration=youtube_min_duration,
+            youtube_max_duration=youtube_max_duration,
+            library_scan_limit=library_scan_limit,
+            music_library_root=music_library_root,
+            lyrics_weight=lyrics_weight,
+            bpm_weight=bpm_weight,
+            tags_weight=tags_weight,
         )
 
 # Async wrapper to process one suggestion
@@ -521,6 +549,20 @@ async def update_settings(
         if m.id.startswith("gpt")
     ]
     settings.getsongbpm_api_key = form_data.getsongbpm_api_key
+    settings.global_min_lfm = form_data.global_min_lfm
+    settings.global_max_lfm = form_data.global_max_lfm
+    settings.cache_ttls = form_data.cache_ttls
+    settings.getsongbpm_base_url = form_data.getsongbpm_base_url
+    settings.getsongbpm_headers = form_data.getsongbpm_headers
+    settings.http_timeout_short = form_data.http_timeout_short
+    settings.http_timeout_long = form_data.http_timeout_long
+    settings.youtube_min_duration = form_data.youtube_min_duration
+    settings.youtube_max_duration = form_data.youtube_max_duration
+    settings.library_scan_limit = form_data.library_scan_limit
+    settings.music_library_root = form_data.music_library_root
+    settings.lyrics_weight = form_data.lyrics_weight
+    settings.bpm_weight = form_data.bpm_weight
+    settings.tags_weight = form_data.tags_weight
 
     save_settings(settings)
 

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -109,6 +109,69 @@
       </div>
     </section>
 
+    <!-- ⚙️ Advanced Settings Section -->
+    <details class="mt-4">
+      <summary class="text-xl font-semibold text-gray-800 dark:text-gray-100 cursor-pointer">⚙️ Advanced Settings</summary>
+      <div class="mt-4 space-y-4">
+        <div class="space-y-2">
+          <label for="GLOBAL_MIN_LFM" class="block font-semibold">Global Min Last.fm Listeners</label>
+          <input type="number" id="GLOBAL_MIN_LFM" name="global_min_lfm" value="{{ settings.global_min_lfm }}" class="w-full p-2 border border-gray-300 rounded dark:bg-gray-300 dark:text-black focus:ring-2 focus:ring-blue-500">
+        </div>
+        <div class="space-y-2">
+          <label for="GLOBAL_MAX_LFM" class="block font-semibold">Global Max Last.fm Listeners</label>
+          <input type="number" id="GLOBAL_MAX_LFM" name="global_max_lfm" value="{{ settings.global_max_lfm }}" class="w-full p-2 border border-gray-300 rounded dark:bg-gray-300 dark:text-black focus:ring-2 focus:ring-blue-500">
+        </div>
+        <div class="space-y-2">
+          <label for="CACHE_TTLS" class="block font-semibold">Cache TTLs (JSON)</label>
+          <textarea id="CACHE_TTLS" name="cache_ttls" rows="4" class="w-full p-2 border border-gray-300 rounded dark:bg-gray-300 dark:text-black focus:ring-2 focus:ring-blue-500">{{ settings.cache_ttls | tojson }}</textarea>
+        </div>
+        <div class="space-y-2">
+          <label for="GETSONGBPM_BASE_URL" class="block font-semibold">GetSongBPM Base URL</label>
+          <input type="text" id="GETSONGBPM_BASE_URL" name="getsongbpm_base_url" value="{{ settings.getsongbpm_base_url }}" class="w-full p-2 border border-gray-300 rounded dark:bg-gray-300 dark:text-black focus:ring-2 focus:ring-blue-500">
+        </div>
+        <div class="space-y-2">
+          <label for="GETSONGBPM_HEADERS" class="block font-semibold">GetSongBPM Headers (JSON)</label>
+          <textarea id="GETSONGBPM_HEADERS" name="getsongbpm_headers" rows="4" class="w-full p-2 border border-gray-300 rounded dark:bg-gray-300 dark:text-black focus:ring-2 focus:ring-blue-500">{{ settings.getsongbpm_headers | tojson }}</textarea>
+        </div>
+        <div class="space-y-2">
+          <label for="HTTP_TIMEOUT_SHORT" class="block font-semibold">HTTP Timeout Short (s)</label>
+          <input type="number" id="HTTP_TIMEOUT_SHORT" name="http_timeout_short" value="{{ settings.http_timeout_short }}" class="w-full p-2 border border-gray-300 rounded dark:bg-gray-300 dark:text-black focus:ring-2 focus:ring-blue-500">
+        </div>
+        <div class="space-y-2">
+          <label for="HTTP_TIMEOUT_LONG" class="block font-semibold">HTTP Timeout Long (s)</label>
+          <input type="number" id="HTTP_TIMEOUT_LONG" name="http_timeout_long" value="{{ settings.http_timeout_long }}" class="w-full p-2 border border-gray-300 rounded dark:bg-gray-300 dark:text-black focus:ring-2 focus:ring-blue-500">
+        </div>
+        <div class="space-y-2">
+          <label for="YOUTUBE_MIN_DURATION" class="block font-semibold">YouTube Min Duration (s)</label>
+          <input type="number" id="YOUTUBE_MIN_DURATION" name="youtube_min_duration" value="{{ settings.youtube_min_duration }}" class="w-full p-2 border border-gray-300 rounded dark:bg-gray-300 dark:text-black focus:ring-2 focus:ring-blue-500">
+        </div>
+        <div class="space-y-2">
+          <label for="YOUTUBE_MAX_DURATION" class="block font-semibold">YouTube Max Duration (s)</label>
+          <input type="number" id="YOUTUBE_MAX_DURATION" name="youtube_max_duration" value="{{ settings.youtube_max_duration }}" class="w-full p-2 border border-gray-300 rounded dark:bg-gray-300 dark:text-black focus:ring-2 focus:ring-blue-500">
+        </div>
+        <div class="space-y-2">
+          <label for="LIBRARY_SCAN_LIMIT" class="block font-semibold">Library Scan Limit</label>
+          <input type="number" id="LIBRARY_SCAN_LIMIT" name="library_scan_limit" value="{{ settings.library_scan_limit }}" class="w-full p-2 border border-gray-300 rounded dark:bg-gray-300 dark:text-black focus:ring-2 focus:ring-blue-500">
+        </div>
+        <div class="space-y-2">
+          <label for="MUSIC_LIBRARY_ROOT" class="block font-semibold">Music Library Root</label>
+          <input type="text" id="MUSIC_LIBRARY_ROOT" name="music_library_root" value="{{ settings.music_library_root }}" class="w-full p-2 border border-gray-300 rounded dark:bg-gray-300 dark:text-black focus:ring-2 focus:ring-blue-500">
+        </div>
+        <div class="space-y-2">
+          <label for="LYRICS_WEIGHT" class="block font-semibold">Lyrics Weight</label>
+          <input type="number" step="0.1" id="LYRICS_WEIGHT" name="lyrics_weight" value="{{ settings.lyrics_weight }}" class="w-full p-2 border border-gray-300 rounded dark:bg-gray-300 dark:text-black focus:ring-2 focus:ring-blue-500">
+        </div>
+        <div class="space-y-2">
+          <label for="BPM_WEIGHT" class="block font-semibold">BPM Weight</label>
+          <input type="number" step="0.1" id="BPM_WEIGHT" name="bpm_weight" value="{{ settings.bpm_weight }}" class="w-full p-2 border border-gray-300 rounded dark:bg-gray-300 dark:text-black focus:ring-2 focus:ring-blue-500">
+        </div>
+        <div class="space-y-2">
+          <label for="TAGS_WEIGHT" class="block font-semibold">Tags Weight</label>
+          <input type="number" step="0.1" id="TAGS_WEIGHT" name="tags_weight" value="{{ settings.tags_weight }}" class="w-full p-2 border border-gray-300 rounded dark:bg-gray-300 dark:text-black focus:ring-2 focus:ring-blue-500">
+        </div>
+      </div>
+    </details>
+
     <!-- Save button at the bottom -->
     <div>
       <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">Save Settings</button>


### PR DESCRIPTION
## Summary
- show all config values in a collapsible section of `settings.html`
- accept and save advanced settings in `SettingsForm`
- store the additional settings in the update route

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bbf12d384833281687f7746862fc1