### PR TITLE
Improve settings UI clarity

### DIFF
--- a/templates/settings.html
+++ b/templates/settings.html
@@ -3,12 +3,13 @@
 
 <main class="container mx-auto p-4">
 
-  <h1 class="text-2xl font-bold mb-4 flex justify-between items-center">
+  <h1 class="text-2xl font-bold flex justify-between items-center mb-1">
     ⚙️ Settings
-    <button type="button" onclick="resetSettings()" class="text-sm px-3 py-1 bg-gray-200 text-gray-800 rounded hover:bg-gray-300 dark:bg-gray-600 dark:text-gray-100 dark:hover:bg-gray-500">
+    <button type="button" onclick="resetSettings()" title="Reset all settings" class="text-sm px-3 py-1 bg-gray-200 text-gray-800 rounded hover:bg-gray-300 dark:bg-gray-600 dark:text-gray-100 dark:hover:bg-gray-500">
       Reset to Defaults
     </button>
   </h1>
+  <p class="text-sm text-gray-600 dark:text-gray-300 mb-4">Manage how Playlist Pilot connects to your services.</p>
 
   {% if validation_message %}
     <div class="bg-yellow-100 border-l-4 border-yellow-400 p-4 mb-4 text-yellow-800">
@@ -19,8 +20,8 @@
   <form method="post" class="space-y-6 bg-white dark:bg-gray-700 p-6 rounded shadow settings-form">
 
     <!-- 🎬 Jellyfin Section -->
-    <section>
-      <h2 class="text-xl font-semibold text-gray-800 dark:text-gray-100 mb-2">🎬 Jellyfin Integration</h2>
+    <fieldset class="mb-4 border border-gray-200 dark:border-gray-600 p-4 rounded">
+      <legend class="px-2 text-lg font-semibold text-gray-800 dark:text-gray-100">🎬 Jellyfin Integration</legend>
 
       <div class="space-y-2">
         <label for="JELLYFIN_URL" class="block font-semibold">Jellyfin URL</label>
@@ -46,11 +47,11 @@
           {% endfor %}
         </select>
       </div>
-    </section>
+    </fieldset>
 
     <!-- 🔑 API Keys Section -->
-    <section>
-      <h2 class="text-xl font-semibold text-gray-800 dark:text-gray-100 mt-4 mb-2">🔑 API Keys</h2>
+    <fieldset class="mb-4 border border-gray-200 dark:border-gray-600 p-4 rounded">
+      <legend class="px-2 text-lg font-semibold text-gray-800 dark:text-gray-100">🔑 API Keys</legend>
 
       <div class="space-y-2">
         <label for="OPENAI_API_KEY" class="block font-semibold">OpenAI API Key</label>
@@ -107,7 +108,7 @@
           <span id="getsongbpm-status" class="text-sm"></span>
         </div>
       </div>
-    </section>
+    </fieldset>
 
     <!-- ⚙️ Advanced Settings Section -->
     <details class="mt-4">
@@ -116,79 +117,102 @@
         <div class="space-y-2">
           <label for="GLOBAL_MIN_LFM" class="block font-semibold">Global Min Last.fm Listeners</label>
           <input type="number" id="GLOBAL_MIN_LFM" name="global_min_lfm" value="{{ settings.global_min_lfm }}" class="w-full p-2 border border-gray-300 rounded dark:bg-gray-300 dark:text-black focus:ring-2 focus:ring-blue-500">
+          <small class="text-gray-300">Minimum listeners a track must have on Last.fm.</small>
         </div>
         <div class="space-y-2">
           <label for="GLOBAL_MAX_LFM" class="block font-semibold">Global Max Last.fm Listeners</label>
           <input type="number" id="GLOBAL_MAX_LFM" name="global_max_lfm" value="{{ settings.global_max_lfm }}" class="w-full p-2 border border-gray-300 rounded dark:bg-gray-300 dark:text-black focus:ring-2 focus:ring-blue-500">
+          <small class="text-gray-300">Maximum listeners threshold for filtering results.</small>
         </div>
         <div class="space-y-2">
           <label for="CACHE_TTLS" class="block font-semibold">Cache TTLs (JSON)</label>
           <textarea id="CACHE_TTLS" name="cache_ttls" rows="4" class="w-full p-2 border border-gray-300 rounded dark:bg-gray-300 dark:text-black focus:ring-2 focus:ring-blue-500">{{ settings.cache_ttls | tojson }}</textarea>
+          <small class="text-gray-300">Customize durations for cached API responses.</small>
         </div>
         <div class="space-y-2">
           <label for="GETSONGBPM_BASE_URL" class="block font-semibold">GetSongBPM Base URL</label>
           <input type="text" id="GETSONGBPM_BASE_URL" name="getsongbpm_base_url" value="{{ settings.getsongbpm_base_url }}" class="w-full p-2 border border-gray-300 rounded dark:bg-gray-300 dark:text-black focus:ring-2 focus:ring-blue-500">
+          <small class="text-gray-300">Override if using a custom instance.</small>
         </div>
         <div class="space-y-2">
           <label for="GETSONGBPM_HEADERS" class="block font-semibold">GetSongBPM Headers (JSON)</label>
           <textarea id="GETSONGBPM_HEADERS" name="getsongbpm_headers" rows="4" class="w-full p-2 border border-gray-300 rounded dark:bg-gray-300 dark:text-black focus:ring-2 focus:ring-blue-500">{{ settings.getsongbpm_headers | tojson }}</textarea>
+          <small class="text-gray-300">JSON headers sent with GetSongBPM requests.</small>
         </div>
         <div class="space-y-2">
           <label for="HTTP_TIMEOUT_SHORT" class="block font-semibold">HTTP Timeout Short (s)</label>
           <input type="number" id="HTTP_TIMEOUT_SHORT" name="http_timeout_short" value="{{ settings.http_timeout_short }}" class="w-full p-2 border border-gray-300 rounded dark:bg-gray-300 dark:text-black focus:ring-2 focus:ring-blue-500">
+          <small class="text-gray-300">Timeout for quick HTTP requests.</small>
         </div>
         <div class="space-y-2">
           <label for="HTTP_TIMEOUT_LONG" class="block font-semibold">HTTP Timeout Long (s)</label>
           <input type="number" id="HTTP_TIMEOUT_LONG" name="http_timeout_long" value="{{ settings.http_timeout_long }}" class="w-full p-2 border border-gray-300 rounded dark:bg-gray-300 dark:text-black focus:ring-2 focus:ring-blue-500">
+          <small class="text-gray-300">Timeout for long-running HTTP requests.</small>
         </div>
         <div class="space-y-2">
           <label for="YOUTUBE_MIN_DURATION" class="block font-semibold">YouTube Min Duration (s)</label>
           <input type="number" id="YOUTUBE_MIN_DURATION" name="youtube_min_duration" value="{{ settings.youtube_min_duration }}" class="w-full p-2 border border-gray-300 rounded dark:bg-gray-300 dark:text-black focus:ring-2 focus:ring-blue-500">
+          <small class="text-gray-300">Ignore videos shorter than this.</small>
         </div>
         <div class="space-y-2">
           <label for="YOUTUBE_MAX_DURATION" class="block font-semibold">YouTube Max Duration (s)</label>
           <input type="number" id="YOUTUBE_MAX_DURATION" name="youtube_max_duration" value="{{ settings.youtube_max_duration }}" class="w-full p-2 border border-gray-300 rounded dark:bg-gray-300 dark:text-black focus:ring-2 focus:ring-blue-500">
+          <small class="text-gray-300">Ignore videos longer than this.</small>
         </div>
         <div class="space-y-2">
           <label for="LIBRARY_SCAN_LIMIT" class="block font-semibold">Library Scan Limit</label>
           <input type="number" id="LIBRARY_SCAN_LIMIT" name="library_scan_limit" value="{{ settings.library_scan_limit }}" class="w-full p-2 border border-gray-300 rounded dark:bg-gray-300 dark:text-black focus:ring-2 focus:ring-blue-500">
+          <small class="text-gray-300">Number of tracks processed per scan.</small>
         </div>
         <div class="space-y-2">
           <label for="MUSIC_LIBRARY_ROOT" class="block font-semibold">Music Library Root</label>
           <input type="text" id="MUSIC_LIBRARY_ROOT" name="music_library_root" value="{{ settings.music_library_root }}" class="w-full p-2 border border-gray-300 rounded dark:bg-gray-300 dark:text-black focus:ring-2 focus:ring-blue-500">
+          <small class="text-gray-300">Path to your Jellyfin music library.</small>
         </div>
         <div class="space-y-2">
           <label for="LYRICS_WEIGHT" class="block font-semibold">Lyrics Weight</label>
           <input type="number" step="0.1" id="LYRICS_WEIGHT" name="lyrics_weight" value="{{ settings.lyrics_weight }}" class="w-full p-2 border border-gray-300 rounded dark:bg-gray-300 dark:text-black focus:ring-2 focus:ring-blue-500">
+          <small class="text-gray-300">Relative weight given to lyric matches.</small>
         </div>
         <div class="space-y-2">
           <label for="BPM_WEIGHT" class="block font-semibold">BPM Weight</label>
           <input type="number" step="0.1" id="BPM_WEIGHT" name="bpm_weight" value="{{ settings.bpm_weight }}" class="w-full p-2 border border-gray-300 rounded dark:bg-gray-300 dark:text-black focus:ring-2 focus:ring-blue-500">
+          <small class="text-gray-300">Relative weight given to BPM similarity.</small>
         </div>
         <div class="space-y-2">
           <label for="TAGS_WEIGHT" class="block font-semibold">Tags Weight</label>
           <input type="number" step="0.1" id="TAGS_WEIGHT" name="tags_weight" value="{{ settings.tags_weight }}" class="w-full p-2 border border-gray-300 rounded dark:bg-gray-300 dark:text-black focus:ring-2 focus:ring-blue-500">
+          <small class="text-gray-300">Relative weight given to tag matches.</small>
         </div>
       </div>
     </details>
 
     <!-- Save button at the bottom -->
-    <div>
+    <div class="flex items-center gap-4">
       <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">Save Settings</button>
+      <a href="/" class="text-sm text-blue-600 hover:underline">Cancel</a>
     </div>
   </form>
 
   <script>
     window.updateStatus = function(id, result, message) {
       const el = document.getElementById(id);
-      if (el) {
-        el.textContent = message;
-        el.className = result ? "text-green-600 text-sm" : "text-red-600 text-sm";
+      if (!el) return;
+
+      if (result === "loading") {
+        el.innerHTML = '<span class="animate-spin mr-1 inline-block">⏳</span>Testing...';
+        el.className = "text-gray-600 text-sm flex items-center";
+        return;
       }
+
+      const icon = result ? "✅" : "❌";
+      el.textContent = icon + " " + message;
+      el.className = result ? "text-green-600 text-sm" : "text-red-600 text-sm";
     };
 
     window.testOpenAIKey = function() {
       const key = document.getElementById("OPENAI_API_KEY").value;
+      window.updateStatus("openai-status", "loading");
       fetch("/api/test/openai", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -202,6 +226,7 @@
     window.testJellyfinKey = function() {
       const url = document.getElementById("JELLYFIN_URL").value;
       const key = document.getElementById("JELLYFIN_API_KEY").value;
+      window.updateStatus("jellyfin-status", "loading");
       fetch("/api/test/jellyfin", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -214,6 +239,7 @@
 
     window.testLastfmKey = function() {
       const key = document.getElementById("LASTFM_API_KEY").value;
+      window.updateStatus("lastfm-status", "loading");
       fetch("/api/test/lastfm", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -226,6 +252,7 @@
 
     window.testGetSongBPMKey = function() {
       const key = document.getElementById("GETSONGBPM_API_KEY").value;
+      window.updateStatus("getsongbpm-status", "loading");
       fetch("/api/test/getsongbpm", {
         method: "POST",
         headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
## Summary
- clarify Settings page title with subtitle and tooltip
- use `fieldset` and `legend` for Jellyfin/API key sections
- add help text for advanced options
- add cancel link and spinner/feedback when testing keys

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bc3634064833283a4a86190026649