### PR TITLE
Fix pylint too-many-lines

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -10,6 +10,7 @@ including:
 - User history view and deletion
 - Settings management
 """
+# pylint: disable=too-many-lines
 
 import asyncio
 import json


### PR DESCRIPTION
## Summary
- add pylint disable comment in api/routes.py to silence module length warning

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bc92c6ff083328701ed61c9aa2e37