### PR TITLE
Fix lint errors and cyclic import

### DIFF
--- a/api/forms.py
+++ b/api/forms.py
@@ -1,6 +1,8 @@
+"""Form utilities for validating settings updates through FastAPI."""
+
+import json
 from fastapi import Form
 from config import AppSettings
-import json
 
 class SettingsForm(AppSettings):
     """Pydantic model for updating application settings via form."""
@@ -43,7 +45,11 @@ class SettingsForm(AppSettings):
             global_max_lfm=global_max_lfm,
             cache_ttls=(json.loads(cache_ttls) if cache_ttls else AppSettings().cache_ttls),
             getsongbpm_base_url=getsongbpm_base_url,
-            getsongbpm_headers=(json.loads(getsongbpm_headers) if getsongbpm_headers else AppSettings().getsongbpm_headers),
+            getsongbpm_headers=(
+                json.loads(getsongbpm_headers)
+                if getsongbpm_headers
+                else AppSettings().getsongbpm_headers
+            ),
             http_timeout_short=http_timeout_short,
             http_timeout_long=http_timeout_long,
             youtube_min_duration=youtube_min_duration,

--- a/api/routes.py
+++ b/api/routes.py
@@ -12,13 +12,10 @@ including:
 """
 # pylint: disable=too-many-lines
 
-import asyncio
-import json
 import logging
 import shutil
 import tempfile
 import uuid
-from datetime import datetime
 from pathlib import Path
 from time import perf_counter
 
@@ -47,7 +44,6 @@ from config import (
 from core.analysis import summarize_tracks
 from core.history import (
     extract_date_from_label,
-    save_user_history,
     save_whole_user_history,
 )
 from core.m3u import (
@@ -67,6 +63,7 @@ from core.playlist import (
     enrich_and_score_suggestions,
 )
 from core.templates import templates
+from core.models import ExportPlaylistRequest
 from services import jellyfin
 from services.gpt import generate_playlist_analysis_summary, fetch_gpt_suggestions
 from services.jellyfin import (
@@ -77,10 +74,8 @@ from services.jellyfin import (
     resolve_jellyfin_path,
 )
 from services.lastfm import get_lastfm_tags
-from services.metube import get_youtube_url_single
 from utils.helpers import get_cached_playlists, load_sorted_history, parse_suggest_request
 from api.forms import SettingsForm
-from core.models import ExportPlaylistRequest
 
 
 logger = logging.getLogger("playlist-pilot")

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -5,7 +5,6 @@ import json
 import logging
 from fastapi import Request
 
-from core.playlist import fetch_audio_playlists
 from core.history import load_user_history, extract_date_from_label
 from utils.cache_manager import playlist_cache, CACHE_TTLS
 from config import settings
@@ -18,6 +17,8 @@ async def get_cached_playlists(user_id: str | None = None) -> dict:
     cache_key = f"playlists:{user_id}"
     playlists_data = playlist_cache.get(cache_key)
     if playlists_data is None:
+        from core.playlist import fetch_audio_playlists
+
         playlists_data = await fetch_audio_playlists()
         playlist_cache.set(cache_key, playlists_data, expire=CACHE_TTLS["playlists"])
     return playlists_data


### PR DESCRIPTION
## Summary
- document settings form module and fix long line
- clean up and reorder route imports
- avoid cyclic import in utils helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bdc6cacf08332a21ce068d84910e7