### PR TITLE
Refactor duplicate popularity logic and break cycles

### DIFF
--- a/services/metube.py
+++ b/services/metube.py
@@ -10,7 +10,7 @@ import logging
 from urllib.parse import quote_plus
 
 import yt_dlp
-from core.playlist import build_search_query, clean
+from utils.text_utils import build_search_query, clean
 from utils.cache_manager import yt_search_cache, CACHE_TTLS
 from config import settings
 

--- a/utils/text_utils.py
+++ b/utils/text_utils.py
@@ -1,0 +1,14 @@
+"""Utility functions for simple text normalization and query building."""
+
+import re
+
+
+def clean(text: str) -> str:
+    """Normalize text by lowercasing and removing punctuation."""
+    return re.sub(r"[^\w\s]", "", text.lower().strip())
+
+
+def build_search_query(line: str) -> str:
+    """Extract a basic search query from a track label."""
+    parts = [part.strip() for part in line.split("-")]
+    return f"{parts[0]} {parts[1]}" if len(parts) >= 2 else line.strip()


### PR DESCRIPTION
## Summary
- break the cyclic import between `core.playlist` and `services.metube`
- move text helpers to `utils.text_utils`
- centralize popularity calculation with `add_combined_popularity`
- update playlist logic and routes to use the new helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bddc2c9f88332bf64aa8708ceaa37