### PR TITLE
Fix unused import warnings

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -33,7 +33,6 @@ from fastapi import (
 )
 from fastapi.responses import HTMLResponse, JSONResponse, FileResponse, RedirectResponse
 from starlette.background import BackgroundTask
-from openai import OpenAI
 
 from config import (
     save_settings,

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -5,10 +5,10 @@ import json
 import logging
 from fastapi import Request
 
-from core.history import load_user_history, extract_date_from_label
-from utils.cache_manager import playlist_cache, CACHE_TTLS
 from config import settings
+from core.history import load_user_history, extract_date_from_label
 from core.playlist import fetch_audio_playlists
+from utils.cache_manager import playlist_cache, CACHE_TTLS
 
 logger = logging.getLogger("playlist-pilot")
 


### PR DESCRIPTION
## Summary
- remove leftover OpenAI import
- group `core` imports in helpers

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pip install pylint astroid` *(fails: Tunnel connection failed)*
- `python -m pylint api/routes.py utils/helpers.py` *(fails: Could not find a version that satisfies the requirement aiofiles)*

------
https://chatgpt.com/codex/tasks/task_e_687becee7f208332a0a4c5ef109747d3