### PR TITLE
Fix async Last.fm lookup

### DIFF
--- a/services/gpt.py
+++ b/services/gpt.py
@@ -216,7 +216,7 @@ async def gpt_suggest_validated(
         artist = track["artist"]
 
         try:
-            track_data = get_lastfm_track_info(title, artist)
+            track_data = await get_lastfm_track_info(title, artist)
             if not track_data:
                 return None
 


### PR DESCRIPTION
## Summary
- correct the missing await when contacting Last.fm

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bf1d9897c8332a3218c1fc52323ad