### PR TITLE
Improve logging detail and levels

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -391,7 +391,7 @@ async def test_jellyfin(request: Request):
         }
         async with httpx.AsyncClient() as client:
             r = await client.get(f"{url}/System/Info", headers=headers)
-        logger.warning("Jellyfin Test: %s", r.text)
+        logger.debug("Jellyfin Test: %s", r.text)
 
         json_data = r.json()
         valid = r.status_code == 200 and any(k.lower() == "version" for k in json_data)

--- a/core/analysis.py
+++ b/core/analysis.py
@@ -139,7 +139,7 @@ def detect_outliers(tracks: List[dict], summary: dict) -> List[str]:
 
 def normalize_popularity(value, min_val, max_val):
     """Normalize a value to a 0-100 scale given its min and max bounds."""
-    logger.info(
+    logger.debug(
         "normalize_popularity called with value=%s, min_val=%s, max_val=%s",
         value,
         min_val,
@@ -149,12 +149,12 @@ def normalize_popularity(value, min_val, max_val):
         logger.warning("normalize_popularity returning 0 due to min_val == max_val")
         return 0
     result = round(100 * (value - min_val) / (max_val - min_val), 2)
-    logger.info("normalize_popularity for jellyfin returning %s", result)
+    logger.debug("normalize_popularity for jellyfin returning %s", result)
     return result
 
 def combined_popularity_score(lastfm, jellyfin, w_lfm=0.4, w_jf=0.6):
     """Combine popularity metrics from Last.fm and Jellyfin."""
-    logger.info(
+    logger.debug(
         "combined_popularity_score called with lastfm=%s, jellyfin=%s, w_lfm=%s, w_jf=%s",
         lastfm,
         jellyfin,
@@ -196,7 +196,7 @@ def combined_popularity_score(lastfm, jellyfin, w_lfm=0.4, w_jf=0.6):
 
 def normalize_popularity_log(value, min_val, max_val):
     """Normalize logarithmic popularity values to a 0-100 scale."""
-    logger.info(
+    logger.debug(
         "normalize_popularity_log called with value=%s, min_val=%s, max_val=%s",
         value,
         min_val,
@@ -420,10 +420,10 @@ def combine_mood_scores(
 ) -> tuple[str, float]:
     """Merge mood scores from tags, BPM analysis and optional lyrics."""
     # pylint: disable=too-many-locals
-    logger.info("\n→ Combining mood scores from Last.fm tags, BPM data, and Lyrics mood:")
-    logger.info("  Raw Tag Scores: %s", tag_scores)
-    logger.info("  Raw BPM Scores: %s", bpm_scores)
-    logger.info("  Raw Lyrics Scores: %s", lyrics_scores)
+    logger.debug("\n→ Combining mood scores from Last.fm tags, BPM data, and Lyrics mood:")
+    logger.debug("  Raw Tag Scores: %s", tag_scores)
+    logger.debug("  Raw BPM Scores: %s", bpm_scores)
+    logger.debug("  Raw Lyrics Scores: %s", lyrics_scores)
 
 
 
@@ -455,7 +455,7 @@ def combine_mood_scores(
     filtered = dict(sorted_moods[:3])
     logger.debug("Filtered mood scores: %s", filtered)
     if not filtered or max(filtered.values()) < 0.3:
-        logger.warning("← Final Mood: unknown (no strong scores)\n")
+        logger.info("← Final Mood: unknown (no strong scores)\n")
         return "unknown", 0.0
 
     # Softmax confidence

--- a/core/m3u.py
+++ b/core/m3u.py
@@ -105,6 +105,7 @@ def read_m3u(file_path: Path) -> list[dict]:
     Returns:
         list[dict]: List of track dictionaries
     """
+    logger.debug("Reading M3U file: %s", file_path)
     tracks = []
 
     lines = file_path.read_text(encoding="utf-8").splitlines()
@@ -119,6 +120,7 @@ def read_m3u(file_path: Path) -> list[dict]:
             "title": title
         })
 
+    logger.info("Parsed %d tracks from %s", len(tracks), file_path)
     return tracks
 
 def infer_track_metadata_from_path(path: str) -> dict:

--- a/core/playlist.py
+++ b/core/playlist.py
@@ -444,12 +444,12 @@ async def enrich_jellyfin_playlist(playlist_id: str, limit: int = 10) -> list[di
         if isinstance(t.get("jellyfin_play_count"), int)
     ]
 
-    logger.info(
+    logger.debug(
         "📊 Last.fm popularity range: min=%s, max=%s",
         min(lastfm_raw, default=0),
         max(lastfm_raw, default=0),
     )
-    logger.info(
+    logger.debug(
         "📊 Jellyfin play count range: min=%s, max=%s",
         min(jellyfin_raw, default=0),
         max(jellyfin_raw, default=0),
@@ -462,11 +462,11 @@ async def enrich_jellyfin_playlist(playlist_id: str, limit: int = 10) -> list[di
         raw_jf = t.get("jellyfin_play_count")
         norm_lfm = normalize_popularity_log(raw_lfm, GLOBAL_MIN_LFM, GLOBAL_MAX_LFM)
         norm_jf = normalize_popularity(raw_jf, 0, max_jf)
-        logger.info("%s", t["title"])
+        logger.debug("%s", t["title"])
         combined = combined_popularity_score(norm_lfm, norm_jf)
         t["combined_popularity"] = combined
 
-        logger.info(
+        logger.debug(
             "📈 %s → LFM: %s (→ %s), JF: %s (→ %s) → Combined: %s",
             t["title"],
             raw_lfm,

--- a/services/getsongbpm.py
+++ b/services/getsongbpm.py
@@ -21,6 +21,7 @@ def get_bpm_from_getsongbpm(
     )
 
     headers = settings.getsongbpm_headers
+    logger.debug("Fetching GetSongBPM URL: %s", search_url)
 
     try:
         data = (
@@ -32,8 +33,9 @@ def get_bpm_from_getsongbpm(
             )
             .json()
         )
+        logger.debug("GetSongBPM response: %s", data)
     except Exception as exc:  # pylint: disable=broad-exception-caught
-        logger.info("GetSongBPM API error: %s", exc)
+        logger.warning("GetSongBPM API error: %s", exc)
         return None
 
     songs = data.get("search", [])
@@ -42,6 +44,7 @@ def get_bpm_from_getsongbpm(
         return None
 
     song = songs[0]
+    logger.debug("Selected song entry: %s", song)
     duration_str = song.get("duration")
     duration_sec = None
     if duration_str and isinstance(duration_str, str) and ":" in duration_str:


### PR DESCRIPTION
## Summary
- refine logging levels across services to avoid noise
- add detailed debug messages for GetSongBPM requests and M3U parsing
- adjust playlist enrichment logs to debug
- switch some analysis info logs to debug
- minor update to Jellyfin test route logging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c0fb3ad748332a5fca3e0eddde0cd