### PR TITLE
Allow configuration after startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ docker compose up --build
 See [Docs/docker_compose_installation.md](Docs/docker_compose_installation.md) for a step-by-step setup guide.
 
 Then open your browser to: [http://localhost:8010](http://localhost:8010)
+If required settings are missing, you'll be automatically redirected to the
+settings page to enter them.
 
 ## ⚙️ Configuration
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -92,6 +92,11 @@ async def index(request: Request):
     Render the homepage with a list of audio playlists.
     Uses cached data if available.
     """
+    try:
+        settings.validate_settings()
+    except ValueError:
+        return RedirectResponse(url="/settings", status_code=302)
+
     user_id = settings.jellyfin_user_id
     playlists_data = await get_cached_playlists(user_id)
     history = load_sorted_history(user_id)

--- a/main.py
+++ b/main.py
@@ -47,8 +47,7 @@ if not logger.handlers:
 try:
     settings.validate_settings()
 except ValueError as e:
-    logger.error("[Startup Error] %s", e)
-    raise SystemExit(1) from e
+    logger.warning("[Startup] Missing configuration: %s", e)
 
 # ─────────────────────────────────────────────────────────────
 # FastAPI App Setup


### PR DESCRIPTION
## Summary
- log a warning instead of exiting when settings are missing
- redirect the home page to `/settings` until config is complete
- document first-run behaviour in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c1a69cdd083329220ad4c1cdcdec9