### PR TITLE
Add dockerignore for build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+cache/
+logs/
+user_data/
+data/


### PR DESCRIPTION
## Summary
- avoid sending large runtime folders to Docker builds
- attempt Docker build to verify directories are ignored

## Testing
- `pytest -q`
- `docker build -t playlist-pilot-test .` *(fails: `command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687cc40aac608332b2d1d760e1a69763