### PR TITLE
Clarify Docker mount paths

### DIFF
--- a/Docs/docker_compose_installation.md
+++ b/Docs/docker_compose_installation.md
@@ -5,7 +5,8 @@ Follow these steps to run **Playlist Pilot** using Docker Compose.
 ## Prerequisites
 
 - Docker and Docker Compose installed
-- Optional: edit `docker-compose.yml` to adjust volume paths for your environment
+- Export `HOST_SETTINGS_FILE` and `HOST_MUSIC_DIR` with the paths to your
+  `settings.json` and music library (or edit `docker-compose.yml` manually)
 
 ## Steps
 
@@ -16,6 +17,8 @@ Follow these steps to run **Playlist Pilot** using Docker Compose.
    ```
 2. **Build and start the containers**
    ```bash
+   HOST_SETTINGS_FILE=/path/to/your/settings.json \
+   HOST_MUSIC_DIR=/path/to/your/music \
    docker compose up --build -d
    ```
    The `-d` flag runs the app in the background. Omit it if you want to follow the logs.

--- a/README.md
+++ b/README.md
@@ -26,11 +26,16 @@ A modular FastAPI app that helps you generate, analyze, and manage music playlis
 
 ## 🐳 Docker Usage
 
-Build and run with Docker Compose:
+Build and run with Docker Compose. Provide the location of your settings file
+and music library using environment variables:
 
 ```bash
+HOST_SETTINGS_FILE=/path/to/your/settings.json \
+HOST_MUSIC_DIR=/path/to/your/music \
 docker compose up --build
 ```
+
+If these variables are not set, the compose file falls back to example paths.
 
 See [Docs/docker_compose_installation.md](Docs/docker_compose_installation.md) for a step-by-step setup guide.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,9 +15,9 @@ services:
       - ./logs:/app/logs
       - ./cache:/app/cache
       - ./user_data:/app/user_data
-      - /mnt/Games/pilotsettings/settings.json:/app/settings.json:rw
+      - ${HOST_SETTINGS_FILE:-/path/to/settings.json}:/app/settings.json:rw
       - ./data:/data # Ensures /data/.cache-spotify is persisted
-      - /mnt/Movies-And-More/Music:/Movies/Music
+      - ${HOST_MUSIC_DIR:-/path/to/Music}:/Movies/Music
     restart: unless-stopped
     healthcheck:
       test:


### PR DESCRIPTION
## Summary
- allow configuring host paths via `HOST_SETTINGS_FILE` and `HOST_MUSIC_DIR`
- document environment variables in README and Docker compose guide

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cc621975c8332b7cfbbe8d3b2233d