### PR TITLE
Allow settings file override

### DIFF
--- a/Docs/docker_compose_installation.md
+++ b/Docs/docker_compose_installation.md
@@ -22,7 +22,9 @@ Follow these steps to run **Playlist Pilot** using Docker Compose.
 3. **Open the web interface**
    Go to [http://localhost:8010](http://localhost:8010) in your browser.
 4. **Configure Playlist Pilot**
-   Visit [http://localhost:8010/settings](http://localhost:8010/settings) to enter API keys and other settings. These persist in `settings.json`.
+   Visit [http://localhost:8010/settings](http://localhost:8010/settings) to enter API keys and other settings.
+   Configuration is saved in `settings.json` (defaults to `/app/settings.json`).
+   Use the `SETTINGS_FILE` environment variable or `--settings-file` option to change the location.
 5. **Stop the containers**
    ```bash
    docker compose down

--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ Visit [http://localhost:8010/settings](http://localhost:8010/settings) to set:
 - Last.fm API key
 - Model (e.g., `gpt-4o-mini`)
 
-These are saved in `settings.json`.
+These are saved in `settings.json` (defaults to `/app/settings.json`).
+Set the `SETTINGS_FILE` environment variable or pass `--settings-file` when
+starting the app to use a different path.
 
 ## 🧪 API Endpoints
 
@@ -71,7 +73,7 @@ These are saved in `settings.json`.
 
 ## 📂 Data Persistence
 
-- `settings.json`: saved settings
+ - `settings.json`: saved settings (defaults to `/app/settings.json`)
 - `logs/`: log output
 - `cache/`: GPT and Jellyfin results
 - `user_data/`: exports and more

--- a/config.py
+++ b/config.py
@@ -11,15 +11,45 @@ This file manages:
 
 import json
 import logging
+import os
+import sys
 from pathlib import Path
 from pydantic import BaseModel
 
 
 # ─────────────────────────────────────────────────────────────
-# Constants
+# Settings file location
 
-#SETTINGS_FILE = Path(__file__).parent / "settings.json"
-SETTINGS_FILE = Path("/app/settings.json")
+SETTINGS_FILE_ENV = "SETTINGS_FILE"
+
+
+def determine_settings_file(argv: list[str] | None = None) -> Path:
+    """Determine the settings file location.
+
+    Order of precedence:
+    1. ``SETTINGS_FILE`` environment variable
+    2. ``--settings-file`` command line option
+    3. Default to ``/app/settings.json``
+    """
+    if argv is None:
+        argv = sys.argv[1:]
+
+    # Environment variable override
+    env_path = os.getenv(SETTINGS_FILE_ENV)
+    if env_path:
+        return Path(env_path)
+
+    # Command line option (--settings-file or --settings-file=PATH)
+    for i, arg in enumerate(argv):
+        if arg.startswith("--settings-file="):
+            return Path(arg.split("=", 1)[1])
+        if arg == "--settings-file" and i + 1 < len(argv):
+            return Path(argv[i + 1])
+
+    return Path("/app/settings.json")
+
+
+SETTINGS_FILE = determine_settings_file()
 """
 Path to the local JSON file where application settings are stored.
 """

--- a/core/constants.py
+++ b/core/constants.py
@@ -2,12 +2,14 @@
 Centralized constants for Playlist Pilot
 """
 from pathlib import Path
+from config import SETTINGS_FILE
 
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 USER_DATA_DIR = BASE_DIR / "user_data"
 # Match the location used in `config.py` so settings are read from the same file
-SETTINGS_FILE = Path("/app/settings.json")
+# (allowing the same overrides)
+# ``SETTINGS_FILE`` is imported from ``config``
 CACHE_DIR = BASE_DIR / "cache"
 LOG_FILE = BASE_DIR / "logs" / "playlist_pilot.log"
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,25 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import config
+
+
+def test_determine_settings_file_env(monkeypatch):
+    monkeypatch.setenv("SETTINGS_FILE", "/tmp/custom.json")
+    path = config.determine_settings_file([])
+    assert path == Path("/tmp/custom.json")
+
+
+def test_determine_settings_file_cli(monkeypatch):
+    monkeypatch.delenv("SETTINGS_FILE", raising=False)
+    path = config.determine_settings_file(["--settings-file", "/tmp/cli.json"])
+    assert path == Path("/tmp/cli.json")
+
+
+def test_determine_settings_file_default(monkeypatch):
+    monkeypatch.delenv("SETTINGS_FILE", raising=False)
+    path = config.determine_settings_file([])
+    assert path == Path("/app/settings.json")


### PR DESCRIPTION
## Summary
- make settings file location configurable
- use the same location in constants
- document how to override the path in README and Docker docs
- add tests for the new logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cc61ccab48332a1373bf34459955c