### PR TITLE
Add tests and pytest instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ A modular FastAPI app that helps you generate, analyze, and manage music playlis
 - `pip install -r requirements.txt` OR use Docker
 - Run tests with `pytest`
 
+### Running Tests
+
+From the project root simply execute:
+
+```bash
+pytest
+```
+
 ## 🐳 Docker Usage
 
 Build and run with Docker Compose. Provide the location of your settings file

--- a/tests/test_lastfm.py
+++ b/tests/test_lastfm.py
@@ -1,0 +1,50 @@
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Stub missing modules
+sys.modules["httpx"] = types.ModuleType("httpx")
+
+cache_mod = types.ModuleType("diskcache")
+class DummyCache(dict):
+    def get(self, k, default=None):
+        return super().get(k, default)
+    def set(self, k, v, expire=None):
+        self[k] = v
+cache_mod.Cache = DummyCache
+sys.modules["diskcache"] = cache_mod
+
+cache_mgr_stub = types.ModuleType("utils.cache_manager")
+cache_mgr_stub.lastfm_cache = DummyCache()
+cache_mgr_stub.CACHE_TTLS = {"lastfm": 60}
+sys.modules["utils.cache_manager"] = cache_mgr_stub
+
+from services import lastfm
+import pytest
+
+
+def test_normalize():
+    assert lastfm.normalize("Foo (Live)") == "foo"
+    assert lastfm.normalize("A&B!") == "ab"
+
+
+def test_enrich_with_lastfm(monkeypatch):
+    async def fake_get_info(title, artist):
+        return {"listeners": "5000", "album": {"releasedate": "1 Jan 2001", "title": "Test"}}
+
+    async def fake_get_tags(title, artist):
+        return ["rock", "indie"]
+
+    monkeypatch.setattr(lastfm, "get_lastfm_track_info", fake_get_info)
+    monkeypatch.setattr(lastfm, "get_lastfm_tags", fake_get_tags)
+
+    import asyncio
+    data = asyncio.run(lastfm.enrich_with_lastfm("Song", "Artist"))
+
+    assert data["exists"] is True
+    assert data["listeners"] == 5000
+    assert data["releasedate"] == "1 Jan 2001"
+    assert data["album"] == "Test"
+    assert data["tags"] == ["rock", "indie"]

--- a/tests/test_playlist_enrichment.py
+++ b/tests/test_playlist_enrichment.py
@@ -1,0 +1,95 @@
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Stub missing third-party modules
+sys.modules.setdefault("httpx", types.ModuleType("httpx"))
+
+# Remove playlist stub from other tests if present
+sys.modules.pop("core.playlist", None)
+
+# Minimal diskcache stub used by utils.cache_manager
+cache_mod = types.ModuleType("diskcache")
+class DummyCache(dict):
+    def get(self, k, default=None):
+        return super().get(k, default)
+    def set(self, k, v, expire=None):
+        self[k] = v
+cache_mod.Cache = DummyCache
+sys.modules.setdefault("diskcache", cache_mod)
+
+# Stub out heavy service modules
+getsongbpm_stub = types.ModuleType("services.getsongbpm")
+getsongbpm_stub.get_cached_bpm = lambda *a, **k: {}
+sys.modules["services.getsongbpm"] = getsongbpm_stub
+
+gpt_stub = types.ModuleType("services.gpt")
+gpt_stub.analyze_mood_from_lyrics = lambda *_a, **_kw: {}
+sys.modules["services.gpt"] = gpt_stub
+
+jellyfin_stub = types.ModuleType("services.jellyfin")
+jellyfin_stub.jf_get = lambda *_a, **_kw: {}
+jellyfin_stub.fetch_tracks_for_playlist_id = lambda *_a, **_kw: []
+jellyfin_stub.fetch_jellyfin_track_metadata = lambda *_a, **_kw: {}
+sys.modules["services.jellyfin"] = jellyfin_stub
+
+metube_stub = types.ModuleType("services.metube")
+metube_stub.get_youtube_url_single = lambda *_a, **_kw: (None, None)
+sys.modules["services.metube"] = metube_stub
+
+# Provide dummy cache manager used by playlist module
+cache_manager_stub = types.ModuleType("utils.cache_manager")
+cache_manager_stub.library_cache = DummyCache()
+cache_manager_stub.CACHE_TTLS = {"full_library": 60}
+sys.modules["utils.cache_manager"] = cache_manager_stub
+
+# Stub analysis helpers
+analysis_stub = types.ModuleType("core.analysis")
+analysis_stub.mood_scores_from_bpm_data = lambda *_a, **_kw: {}
+analysis_stub.mood_scores_from_lastfm_tags = lambda *_a, **_kw: {}
+analysis_stub.combine_mood_scores = lambda *_a, **_kw: ("Neutral", 0.0)
+analysis_stub.normalize_popularity = lambda v, *_a: v or 0
+analysis_stub.combined_popularity_score = lambda *_a, **_kw: 0
+analysis_stub.normalize_popularity_log = lambda v, *_a: v or 0
+analysis_stub.build_lyrics_scores = lambda *_a, **_kw: {}
+analysis_stub.add_combined_popularity = lambda *_a, **_kw: None
+analysis_stub.summarize_tracks = lambda *_a, **_kw: {}
+sys.modules.setdefault("core.analysis", analysis_stub)
+
+# services.lastfm will be patched in tests
+lfm_stub = types.ModuleType("services.lastfm")
+async def _dummy_enrich(*_a, **_kw):
+    return {"tags": [], "listeners": 0, "album": ""}
+lfm_stub.enrich_with_lastfm = _dummy_enrich
+sys.modules["services.lastfm"] = lfm_stub
+
+from core.playlist import (
+    parse_suggestion_line,
+    extract_tag_value,
+    infer_decade,
+    enrich_track,
+)
+from core.models import Track
+
+import pytest
+
+
+def test_parse_suggestion_line():
+    text, reason = parse_suggestion_line(
+        "Song - Artist - Album - 1999 - Because it's great"
+    )
+    assert text == "Song - Artist - Album - 1999"
+    assert reason == "Because it's great"
+
+
+def test_extract_tag_value():
+    tags = ["tempo:120", "mood:happy"]
+    assert extract_tag_value(tags, "tempo") == "120"
+    assert extract_tag_value(tags, "genre") is None
+
+
+def test_infer_decade():
+    assert infer_decade("1999") == "1990s"
+    assert infer_decade("abc") == "Unknown"

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,119 @@
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Stub heavy dependencies to allow importing main app
+jinja2_stub = types.ModuleType("jinja2")
+sys.modules["jinja2"] = jinja2_stub
+sys.modules["openai"] = types.ModuleType("openai")
+sys.modules.pop("core.playlist", None)
+multipart_pkg = types.ModuleType("multipart")
+multipart_sub = types.ModuleType("multipart.multipart")
+multipart_sub.parse_options_header = lambda *_a, **_kw: ("", {})
+multipart_pkg.__version__ = "0"
+sys.modules["multipart"] = multipart_pkg
+sys.modules["multipart.multipart"] = multipart_sub
+os.makedirs("logs", exist_ok=True)
+
+cache_mod = types.ModuleType("diskcache")
+class DummyCache(dict):
+    def get(self, k, default=None):
+        return super().get(k, default)
+    def set(self, k, v, expire=None):
+        self[k] = v
+cache_mod.Cache = DummyCache
+sys.modules.setdefault("diskcache", cache_mod)
+
+# services stubs used during import
+for name in [
+    "services.jellyfin",
+    "services.gpt",
+    "services.getsongbpm",
+    "services.metube",
+]:
+    mod = types.ModuleType(name)
+    if name == "services.getsongbpm":
+        mod.get_cached_bpm = lambda *a, **kw: {}
+    if name == "services.jellyfin":
+        mod.jf_get = lambda *_a, **_kw: {}
+        mod.fetch_tracks_for_playlist_id = lambda *_a, **_kw: []
+        mod.fetch_jellyfin_track_metadata = lambda *_a, **_kw: {}
+        mod.create_jellyfin_playlist = lambda *_a, **_kw: {}
+        mod.fetch_jellyfin_users = lambda *_a, **_kw: []
+        mod.resolve_jellyfin_path = lambda *_a, **_kw: ""
+    if name == "services.gpt":
+        mod.analyze_mood_from_lyrics = lambda *_a, **_kw: {}
+        mod.generate_playlist_analysis_summary = lambda *_a, **_kw: ("", [])
+        mod.fetch_gpt_suggestions = lambda *_a, **_kw: []
+        mod.fetch_openai_models = lambda *_a, **_kw: []
+    if name == "services.metube":
+        mod.get_youtube_url_single = lambda *_a, **_kw: (None, None)
+    sys.modules[name] = mod
+
+cache_mgr_stub = types.ModuleType("utils.cache_manager")
+cache_mgr_stub.lastfm_cache = DummyCache()
+cache_mgr_stub.CACHE_TTLS = {"lastfm": 60}
+cache_mgr_stub.library_cache = DummyCache()
+cache_mgr_stub.playlist_cache = DummyCache()
+sys.modules["utils.cache_manager"] = cache_mgr_stub
+
+# Minimal templates stub
+templates_mod = types.ModuleType("core.templates")
+class DummyTemplates:
+    def TemplateResponse(self, *_a, **_kw):
+        return ""
+templates_mod.templates = DummyTemplates()
+sys.modules["core.templates"] = templates_mod
+
+# Stub services.lastfm for import; real functions will be patched later
+lfm_mod = types.ModuleType("services.lastfm")
+async def dummy_get_tags(*_a, **_kw):
+    return []
+lfm_mod.get_lastfm_tags = dummy_get_tags
+async def dummy_enrich(*_a, **_kw):
+    return {}
+lfm_mod.enrich_with_lastfm = dummy_enrich
+sys.modules["services.lastfm"] = lfm_mod
+
+import asyncio
+from api import routes
+import pytest
+
+
+def test_health():
+    assert asyncio.run(routes.health_check()) == {"status": "ok"}
+
+
+def test_lastfm_route(monkeypatch):
+
+    async def fake_get(url, params=None, **_kw):
+        class Resp:
+            status_code = 200
+            def json(self):
+                return {"results": {}}
+        return Resp()
+
+    httpx_mod = types.ModuleType("httpx")
+    class DummyClient:
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+        async def get(self, *a, **kw):
+            return await fake_get(*a, **kw)
+    httpx_mod.AsyncClient = DummyClient
+    httpx_mod.HTTPError = Exception
+    monkeypatch.setitem(sys.modules, "httpx", httpx_mod)
+    monkeypatch.setattr(routes, "httpx", httpx_mod)
+
+    class DummyRequest:
+        async def json(self):
+            return {"key": "abc"}
+
+    request = DummyRequest()
+    response = asyncio.run(routes.test_lastfm(request))
+    assert response.status_code == 200
+    import json
+    assert json.loads(response.body)["success"] is True


### PR DESCRIPTION
## Summary
- add unit tests for playlist enrichment helpers
- add unit tests for Last.fm service
- add API route tests
- document how to run tests in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cc92053448332969955a347ba754d