### PR TITLE
Add basic unit tests

### DIFF
--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,0 +1,53 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from core.analysis import (
+    combined_popularity_score,
+    add_combined_popularity,
+    summarize_tracks,
+)
+
+
+def test_combined_popularity_score_basic():
+    assert combined_popularity_score(50, 50) == 50
+    assert combined_popularity_score(None, 80) == 80
+    assert combined_popularity_score(40, None) == 40
+    assert combined_popularity_score(None, None) is None
+
+
+def test_add_combined_popularity():
+    tracks = [
+        {"jellyfin_play_count": 10, "popularity": 5000},
+        {"jellyfin_play_count": 20, "popularity": 10000},
+    ]
+    result = add_combined_popularity(tracks, w_lfm=0.5, w_jf=0.5)
+    assert all("combined_popularity" in t for t in result)
+
+
+def test_summarize_tracks_basic():
+    tracks = [
+        {
+            "genre": "rock",
+            "mood": "happy",
+            "tempo": 120,
+            "decade": "2000s",
+            "combined_popularity": 60,
+            "popularity": 100,
+            "title": "A",
+        },
+        {
+            "genre": "rock",
+            "mood": "happy",
+            "tempo": 126,
+            "decade": "2000s",
+            "combined_popularity": 70,
+            "popularity": 120,
+            "title": "B",
+        },
+    ]
+    summary = summarize_tracks(tracks)
+    assert summary["dominant_genre"] == "rock"
+    assert summary["tempo_avg"] == 123
+    assert summary["avg_popularity"] == 65

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -1,0 +1,25 @@
+import os
+import sys
+import ast
+from pathlib import Path
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+def _extract_health_check():
+    src = Path("api/routes.py").read_text()
+    tree = ast.parse(src)
+    func = next(n for n in tree.body if isinstance(n, ast.AsyncFunctionDef) and n.name == "health_check")
+    func.decorator_list = []
+    module = ast.Module(body=[func], type_ignores=[])
+    ns = {}
+    exec(compile(module, filename="<health>", mode="exec"), ns)
+    return ns["health_check"]
+
+
+def test_health_check():
+    health_check = _extract_health_check()
+    import asyncio
+    result = asyncio.get_event_loop().run_until_complete(health_check())
+    assert result == {"status": "ok"}

--- a/tests/test_gpt_jellyfin.py
+++ b/tests/test_gpt_jellyfin.py
@@ -1,0 +1,100 @@
+import os
+import sys
+import types
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Stub httpx for jellyfin service
+class DummyResp:
+    def __init__(self, items):
+        self._items = items
+        self.status_code = 200
+    def json(self):
+        return {"Items": self._items}
+    def raise_for_status(self):
+        pass
+
+class DummyClient:
+    def __init__(self, items):
+        self._items = items
+    async def __aenter__(self):
+        return self
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+    async def get(self, *args, **kwargs):
+        return DummyResp(self._items)
+
+def make_httpx_stub(items):
+    module = types.ModuleType("httpx")
+    module.AsyncClient = lambda *a, **kw: DummyClient(items)
+    return module
+
+# Stub diskcache Cache used by jellyfin module
+class DummyCache(dict):
+    def get(self, key):
+        return None
+    def set(self, key, value, expire=None):
+        self[key] = value
+
+sys.modules["diskcache"] = types.ModuleType("diskcache")
+sys.modules["diskcache"].Cache = DummyCache
+
+# Stub utils.cache_manager used inside jellyfin
+cache_stub = types.ModuleType("utils.cache_manager")
+cache_stub.jellyfin_track_cache = DummyCache()
+cache_stub.CACHE_TTLS = {"jellyfin_tracks": 1}
+sys.modules["utils.cache_manager"] = cache_stub
+
+
+def test_search_jellyfin_track_found(monkeypatch):
+    sys.modules["httpx"] = make_httpx_stub([{"Name": "My Song", "Artists": ["My Artist"]}])
+    sys.modules.pop("services.jellyfin", None)
+    from services import jellyfin  # import after stubbing
+    monkeypatch.setattr(jellyfin, "jellyfin_track_cache", DummyCache())
+    import asyncio
+    found = asyncio.get_event_loop().run_until_complete(
+        jellyfin.search_jellyfin_for_track("My Song", "My Artist")
+    )
+    assert found is True
+
+
+def test_search_jellyfin_track_not_found(monkeypatch):
+    sys.modules["httpx"] = make_httpx_stub([])
+    sys.modules.pop("services.jellyfin", None)
+    from services import jellyfin
+    monkeypatch.setattr(jellyfin, "jellyfin_track_cache", DummyCache())
+    import asyncio
+    found = asyncio.get_event_loop().run_until_complete(
+        jellyfin.search_jellyfin_for_track("Other", "Artist")
+    )
+    assert found is False
+
+
+def test_parse_gpt_line():
+    # Stub openai so importing services.gpt succeeds
+    openai_stub = types.ModuleType("openai")
+    class Dummy:
+        def __init__(self, **kwargs):
+            pass
+    openai_stub.OpenAI = Dummy
+    openai_stub.AsyncOpenAI = Dummy
+    openai_stub.OpenAIError = Exception
+    sys.modules["openai"] = openai_stub
+    # Stub utils.cache_manager for gpt
+    cache_stub = types.ModuleType("utils.cache_manager")
+    cache_stub.prompt_cache = DummyCache()
+    cache_stub.lastfm_cache = DummyCache()
+    cache_stub.CACHE_TTLS = {"prompt": 1}
+    sys.modules["utils.cache_manager"] = cache_stub
+    from services.gpt import parse_gpt_line, describe_popularity
+
+    title, artist = parse_gpt_line("Song - Artist - Album - 2020 - Reason")
+    assert title == "Song"
+    assert artist == "Artist"
+
+    assert describe_popularity(95) == "Global smash hit"
+    assert describe_popularity(75) == "Mainstream favorite"
+    assert describe_popularity(55) == "Moderately mainstream"
+    assert describe_popularity(35) == "Niche appeal"
+    assert describe_popularity(10) == "Obscure or local"


### PR DESCRIPTION
## Summary
- expand test coverage for analysis helpers
- add API health check test via AST extraction
- test Jellyfin search logic and GPT utilities with stubs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cf500a1088332bc434137a74f4a41