### PR TITLE
Integrate black format checking

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -18,9 +18,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install pylint astroid pytest pytest-cov
+        pip install pylint astroid pytest pytest-cov black
     - name: Set PYTHONPATH
       run: echo "PYTHONPATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+    - name: Check formatting with black
+      run: black --check .
     - name: Analysing the code with pylint
       run: pylint $(git ls-files '*.py')
     - name: Run tests

--- a/README.md
+++ b/README.md
@@ -90,11 +90,15 @@ All values are saved in `settings.json` in the project root or mounted volume.
    ```bash
    pytest
    ```
-4. Lint the code:
+4. Format the code:
+   ```bash
+   black .
+   ```
+5. Lint the code:
    ```bash
    pylint core api services utils
    ```
-5. Push your branch and open a pull request against `main`.
+6. Push your branch and open a pull request against `main`.
 
 For additional setup guidance see the files in the [Docs](Docs/) directory.
 See the [ROADMAP](ROADMAP.md) for future plans and open issues.


### PR DESCRIPTION
## Summary
- run `black --check` in the lint workflow
- document formatting step in the contributor guide

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cf84f82648332984cc495d638059a