### PR TITLE
Improve Docker setup docs

### DIFF
--- a/Docs/docker_compose_installation.md
+++ b/Docs/docker_compose_installation.md
@@ -5,7 +5,8 @@ Follow these steps to run **Playlist Pilot** using Docker Compose.
 ## Prerequisites
 
 - Docker and Docker Compose installed
-- Optional: edit `docker-compose.yml` to adjust volume paths for your environment
+- Copy `env.example` to `.env` and update the paths and API keys for your environment.
+  Docker Compose will substitute these values into `docker-compose.yml`.
 
 ## Steps
 
@@ -14,16 +15,21 @@ Follow these steps to run **Playlist Pilot** using Docker Compose.
    git clone <REPO_URL>
    cd playlist-pilot
    ```
-2. **Build and start the containers**
+2. **Configure paths and secrets**
+   Copy `env.example` to `.env` and update the variables to match your system.
+   This file controls where logs, cache and other data are stored and can hold
+   your API keys. The provided `docker-compose.yml` uses these variables for
+   volume mounts so you can keep data anywhere you like.
+3. **Build and start the containers**
    ```bash
    docker compose up --build -d
    ```
    The `-d` flag runs the app in the background. Omit it if you want to follow the logs.
-3. **Open the web interface**
+4. **Open the web interface**
    Go to [http://localhost:8010](http://localhost:8010) in your browser.
-4. **Configure Playlist Pilot**
+5. **Configure Playlist Pilot**
    Visit [http://localhost:8010/settings](http://localhost:8010/settings) to enter API keys and other settings. These persist in `settings.json`.
-5. **Stop the containers**
+6. **Stop the containers**
    ```bash
    docker compose down
    ```

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Playlist Pilot is a FastAPI application that generates and manages music playlis
 
 ## Docker Usage
 
+Copy `env.example` to `.env` and update the paths for your machine. Docker
+Compose will read this file and mount the specified directories and
+`settings.json` into the container.
+
 Use Docker Compose to build and start the app:
 
 ```bash
@@ -42,6 +46,8 @@ Navigate to [http://localhost:8010/settings](http://localhost:8010/settings) and
 - Preferred GPT model (for example `gpt-4o-mini`)
 
 All values are saved in `settings.json` in the project root or mounted volume.
+You can also place these keys in your `.env` file so they are available when the
+container first starts.
 
 ## API Endpoints
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,19 +5,21 @@ services:
       context: .
       dockerfile: Dockerfile
     working_dir: /app
+    env_file:
+      - .env
     environment:
-      - PYTHONPATH=/app
-      - TZ=America/New_York
-      - PYTHONUNBUFFERED=1
+      PYTHONPATH: /app
+      TZ: ${TZ:-UTC}
+      PYTHONUNBUFFERED: 1
     ports:
       - 8010:8000
     volumes:
-      - ./logs:/app/logs
-      - ./cache:/app/cache
-      - ./user_data:/app/user_data
-      - /mnt/Games/pilotsettings/settings.json:/app/settings.json:rw
+      - ${LOGS_DIR:-./logs}:/app/logs
+      - ${CACHE_DIR:-./cache}:/app/cache
+      - ${USER_DATA_DIR:-./user_data}:/app/user_data
+      - ${SETTINGS_PATH:-./settings.json}:/app/settings.json:rw
       - ./data:/data # Ensures /data/.cache-spotify is persisted
-      - /mnt/Movies-And-More/Music:/Movies/Music
+      - ${MUSIC_DIR:-/mnt/Movies-And-More/Music}:/Movies/Music
     restart: unless-stopped
     healthcheck:
       test:

--- a/env.example
+++ b/env.example
@@ -1,0 +1,18 @@
+# Example environment variables for Playlist Pilot
+
+# Container timezone
+TZ=America/New_York
+
+# Host directories for persistent data
+LOGS_DIR=./logs
+CACHE_DIR=./cache
+USER_DATA_DIR=./user_data
+# Path to your settings file
+SETTINGS_PATH=/path/to/settings.json
+# Location of your music library
+MUSIC_DIR=/mnt/Music
+
+# Optional API keys if prepopulating settings.json
+OPENAI_API_KEY=
+LASTFM_API_KEY=
+GETSONGBPM_API_KEY=


### PR DESCRIPTION
## Summary
- update `docker-compose.yml` to use environment variables
- provide `env.example` for paths and API secrets
- document environment setup in README and Docker Compose guide

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cf9345c648332bad66cb7a972ce97