### PR TITLE
Add API credential security guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ Thumbs.db
 cache/
 logs/
 user_data/
+.env
+settings.json

--- a/Docs/secure_credentials.md
+++ b/Docs/secure_credentials.md
@@ -1,0 +1,22 @@
+# Securing API Credentials
+
+Playlist Pilot relies on multiple external services that require API keys. Follow these guidelines to keep your credentials safe.
+
+## Environment variables
+
+- Use the provided `env.example` as a template and create a `.env` file for your real values.
+- Never commit the `.env` file to version control. It should be listed in `.gitignore`.
+- When running without Docker, export the variables in your shell or use a tool like `direnv`.
+
+## Docker secrets
+
+- In Docker Swarm or compose v3+ you can store secrets using the `docker secret` command.
+- Create a secret: `printf "<your-key>" | docker secret create openai_api_key -`.
+- Update your Compose or Swarm service to read the secret at `/run/secrets/openai_api_key`.
+
+## Avoid plain-text configuration
+
+- Keep `settings.json` outside of your repository and mount it when starting the container.
+- Do not hardcode API keys in source files or commit them to version control.
+
+Following these practices helps prevent accidental leakage of sensitive information.

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Navigate to [http://localhost:8010/settings](http://localhost:8010/settings) and
 - Preferred GPT model (for example `gpt-4o-mini`)
 
 All values are saved in `settings.json` in the project root or mounted volume.
-You can also place these keys in your `.env` file so they are available when the
-container first starts.
+You can also place these keys in your `.env` file so they are available when the container first starts.
+Read [Docs/secure_credentials.md](Docs/secure_credentials.md) for tips on keeping API keys and other secrets out of your repository.
 
 ## API Endpoints
 


### PR DESCRIPTION
## Summary
- document how to keep API credentials out of version control
- reference security doc in README
- ignore `.env` and `settings.json`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cfa7d636083329e8601eee6252cd2