### PR TITLE
Improve error handling and user feedback

### DIFF
--- a/templates/analyze.html
+++ b/templates/analyze.html
@@ -5,6 +5,11 @@
 <main class="container mx-auto max-w-4xl p-4">
   <div class="p-6 bg-white dark:bg-gray-800 rounded-lg shadow border border-gray-200 dark:border-gray-700">
     <h1 class="text-2xl font-bold mb-6">🧠 Analyze Playlist</h1>
+    {% if error_message %}
+    <div class="mb-4 p-2 rounded bg-red-100 text-red-800">
+      ❌ {{ error_message }}
+    </div>
+    {% endif %}
 
     <form method="post" action="/analyze/result" class="space-y-6" onsubmit="showSpinner()">
       <div>

--- a/templates/compare.html
+++ b/templates/compare.html
@@ -4,6 +4,11 @@
 {% block content %}
 <main class="container mx-auto p-4">
   <h1 class="text-2xl font-bold mb-6">🔍 Compare Playlists</h1>
+  {% if error_message %}
+  <div class="mb-4 p-2 rounded bg-red-100 text-red-800">
+    ❌ {{ error_message }}
+  </div>
+  {% endif %}
 
   <form id="compare-form" method="POST" action="/compare" class="space-y-6 bg-white dark:bg-gray-700 p-6 rounded shadow"  onsubmit="showSpinner()">
     <div class="flex flex-col md:flex-row gap-6">

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -16,6 +16,16 @@
       ⚠️ <strong>Configuration Warning:</strong> {{ validation_message }}
     </div>
   {% endif %}
+  {% if jellyfin_users|length == 0 %}
+    <div class="bg-red-100 p-2 rounded mb-4 text-red-800">
+      ❌ Unable to fetch Jellyfin users. Check your Jellyfin settings.
+    </div>
+  {% endif %}
+  {% if models|length == 0 %}
+    <div class="bg-red-100 p-2 rounded mb-4 text-red-800">
+      ❌ Unable to fetch OpenAI models. Verify your API key.
+    </div>
+  {% endif %}
 
   <form method="post" class="space-y-6 bg-white dark:bg-gray-700 p-6 rounded shadow settings-form">
 


### PR DESCRIPTION
## Summary
- add error handling helper for Jellyfin API requests
- return any Jellyfin errors when fetching playlists
- propagate playlist errors to templates
- show service error messages on analysis, compare, and settings pages
- add caching fallback when playlist fetch fails

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cfb02f3f0833290961f7c34e2df25