### PR TITLE
Expand documentation with architecture and usage guides

### DIFF
--- a/Docs/api_reference.md
+++ b/Docs/api_reference.md
@@ -1,0 +1,27 @@
+# API Reference
+
+The table below summarises the main endpoints exposed by Playlist Pilot. All endpoints return JSON or HTML depending on the route.
+
+| Method | Path | Description |
+|-------|------|-------------|
+| GET | `/` | Home page showing Jellyfin playlists and history |
+| POST | `/suggest` | Generate a playlist from manual input |
+| GET | `/analyze` | Choose a playlist for analysis |
+| POST | `/analyze/result` | Display analysis results |
+| POST | `/analyze/export-m3u` | Export analyzed tracks as M3U |
+| POST | `/suggest-playlist` | Suggest a playlist from analysis results |
+| GET | `/compare` | Display comparison form |
+| POST | `/compare` | Compare two playlists |
+| GET | `/history` | View past GPT suggestions |
+| POST | `/history/delete` | Delete a history entry |
+| GET | `/history/export` | Export a history entry as `.m3u` |
+| POST | `/import_m3u` | Import an `.m3u` file |
+| POST | `/export/jellyfin` | Create a Jellyfin playlist |
+| POST | `/export/track-metadata` | Update Jellyfin track metadata |
+| GET | `/settings` | View current configuration |
+| POST | `/settings` | Update settings |
+| POST | `/api/test/lastfm` | Verify Last.fm connectivity |
+| POST | `/api/test/jellyfin` | Verify Jellyfin connectivity |
+| GET | `/health` | Simple health check |
+
+Return codes generally follow HTTP conventions: 200 for success, 4xx for invalid input and 5xx for unexpected errors.

--- a/Docs/architecture.md
+++ b/Docs/architecture.md
@@ -1,0 +1,12 @@
+# Architecture Overview
+
+Playlist Pilot is organized into a few key packages:
+
+- **`main.py`** – application entry point that configures logging, loads settings and creates the FastAPI app.
+- **`api/`** – request handlers and HTML forms. `routes.py` registers all endpoints and uses services and core helpers.
+- **`core/`** – core business logic such as playlist analysis, history management and template helpers.
+- **`services/`** – integrations with external APIs like Jellyfin, Last.fm, OpenAI and GetSongBPM.
+- **`utils/`** – utility modules including caching helpers.
+- **`templates/`** and **`static/`** – Jinja2 templates and static assets for the web UI.
+
+Settings are managed via `config.py` and stored in `settings.json`. Caching uses DiskCache in the `cache/` directory. The FastAPI app serves both the HTML interface and JSON endpoints. Tests live in the `tests/` directory.

--- a/Docs/contributing.md
+++ b/Docs/contributing.md
@@ -1,0 +1,21 @@
+# Contributing Guide
+
+Thank you for considering a contribution to Playlist Pilot! To get started:
+
+1. **Fork the repository** and create a descriptive feature branch.
+2. **Install dependencies**:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. **Run the tests** to ensure everything passes:
+   ```bash
+   pytest
+   ```
+4. **Format** and **lint** your code:
+   ```bash
+   black .
+   pylint core api services utils
+   ```
+5. Commit your changes and open a **pull request** against `main`. Include a clear description of your changes.
+
+Feel free to open an issue first if you want to discuss a feature or bug fix.

--- a/Docs/local_installation.md
+++ b/Docs/local_installation.md
@@ -1,0 +1,18 @@
+# Local Installation
+
+You can run Playlist Pilot without Docker by installing the Python requirements and running the app directly.
+
+1. **Clone the repo** and install dependencies:
+   ```bash
+   git clone <REPO_URL>
+   cd playlist-pilot
+   pip install -r requirements.txt
+   ```
+2. **Create a settings file** by copying `env.example` to `.env` and filling in your API keys and paths. You can also create `settings.json` manually following the fields in `config.py`.
+3. **Start the server**:
+   ```bash
+   uvicorn main:app --reload --port 8010
+   ```
+4. Visit [http://localhost:8010](http://localhost:8010) and configure the application via the settings page.
+
+Logs and cache files are stored in the directories defined by your environment variables.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Playlist Pilot is a FastAPI application that generates and manages music playlists using GPT, Jellyfin and a few helper services. It caches results on disk so repeated requests stay fast and ships with a small web UI built with Jinja2 and Tailwind.
 
+See [Docs/architecture.md](Docs/architecture.md) for a high level overview of the code structure.
+
 ## Features
 
 - **Playlist suggestions** from moods, genres or existing songs using GPT with Last.fm metadata and Jellyfin library sampling.
@@ -35,6 +37,17 @@ docker compose up --build
 
 A step‑by‑step guide is available in [Docs/docker_compose_installation.md](Docs/docker_compose_installation.md). Once running, visit [http://localhost:8010](http://localhost:8010). If required settings are missing you'll be redirected to the settings page.
 
+## Running Locally
+
+To start the application without Docker install the dependencies and run Uvicorn:
+
+```bash
+pip install -r requirements.txt
+uvicorn main:app --reload --port 8010
+```
+
+See [Docs/local_installation.md](Docs/local_installation.md) for a detailed walkthrough.
+
 ## Configuration
 
 Navigate to [http://localhost:8010/settings](http://localhost:8010/settings) and supply:
@@ -47,31 +60,11 @@ Navigate to [http://localhost:8010/settings](http://localhost:8010/settings) and
 
 All values are saved in `settings.json` in the project root or mounted volume.
 You can also place these keys in your `.env` file so they are available when the container first starts.
-Read [Docs/secure_credentials.md](Docs/secure_credentials.md) for tips on keeping API keys and other secrets out of your repository.
+Read [Docs/secure_credentials.md](Docs/secure_credentials.md) for tips on keeping API keys and other secrets out of your repository. An example set of environment variables is provided in [env.example](env.example).
 
 ## API Endpoints
 
-| Method | Path | Description |
-|-------|------|-------------|
-| GET | `/` | Home page / manual suggestions |
-| POST | `/suggest` | Suggest tracks from form input |
-| GET | `/analyze` | Analyze a Jellyfin or history playlist |
-| POST | `/analyze/result` | Display analysis results |
-| POST | `/analyze/export-m3u` | Export analysis results as M3U |
-| POST | `/suggest-playlist` | Suggest playlist from analysis |
-| GET | `/compare` | Playlist comparison form |
-| POST | `/compare` | Compare two playlists |
-| GET | `/history` | View suggestion history |
-| POST | `/history/delete` | Delete a history entry |
-| GET | `/history/export` | Export a history entry as `.m3u` |
-| POST | `/import_m3u` | Import an `.m3u` into history |
-| POST | `/export/jellyfin` | Create a Jellyfin playlist |
-| POST | `/export/track-metadata` | Update Jellyfin track metadata |
-| GET | `/settings` | Show settings form |
-| POST | `/settings` | Update settings |
-| POST | `/api/test/lastfm` | Check Last.fm connectivity |
-| POST | `/api/test/jellyfin` | Check Jellyfin connectivity |
-| GET | `/health` | Health check |
+The API is exposed via several HTTP routes. A full table describing each route is available in [Docs/api_reference.md](Docs/api_reference.md).
 
 ## Data Persistence
 
@@ -87,6 +80,8 @@ Read [Docs/secure_credentials.md](Docs/secure_credentials.md) for tips on keepin
 - DiskCache for persistent caching
 - yt-dlp for YouTube lookups
 - Jellyfin, Last.fm and GetSongBPM integrations
+
+The overall architecture is described in [Docs/architecture.md](Docs/architecture.md).
 
 ## Contributing
 
@@ -106,7 +101,7 @@ Read [Docs/secure_credentials.md](Docs/secure_credentials.md) for tips on keepin
    ```
 6. Push your branch and open a pull request against `main`.
 
-For additional setup guidance see the files in the [Docs](Docs/) directory.
+For additional details see [Docs/contributing.md](Docs/contributing.md) and the other documents in the [Docs](Docs/) directory.
 See the [ROADMAP](ROADMAP.md) for future plans and open issues.
 
 ## License


### PR DESCRIPTION
## Summary
- add architecture overview
- provide full API reference
- document local installation
- add contribution guidelines
- reference new docs from README and update usage section

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cfd0d03088332864d98f33181efb9