### PR TITLE
Fix Pylint warnings in tests

### DIFF
--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,10 +1,5 @@
 """Tests for functions in ``core.analysis``."""
 
-import os
-import sys
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 from core.analysis import (
     combined_popularity_score,
     add_combined_popularity,

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -1,12 +1,10 @@
 """Tests for minimal FastAPI route helpers."""
 
-import os
-import sys
+# pylint: disable=exec-used
+
 import ast
 from pathlib import Path
 import asyncio
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 
 def _extract_health_check():

--- a/tests/test_m3u.py
+++ b/tests/test_m3u.py
@@ -1,10 +1,9 @@
 """Unit tests for M3U parsing utilities."""
 
-import os
+# pylint: disable=wrong-import-position
+
 import sys
 import types
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 # Stub optional dependencies to allow importing core.m3u without installing them
 sys.modules.setdefault('httpx', types.ModuleType('httpx'))


### PR DESCRIPTION
## Summary
- clean up imports in tests
- add missing docstrings and small clarifications for stubs
- silence false positive warnings

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d0693ce608332b905a8b468a3160f