### PR TITLE
Fix settings path for tests

### DIFF
--- a/config.py
+++ b/config.py
@@ -11,6 +11,7 @@ This file manages:
 
 import json
 import logging
+import os
 from pathlib import Path
 from pydantic import BaseModel
 
@@ -18,8 +19,12 @@ from pydantic import BaseModel
 # ─────────────────────────────────────────────────────────────
 # Constants
 
-#SETTINGS_FILE = Path(__file__).parent / "settings.json"
-SETTINGS_FILE = Path("/app/settings.json")
+SETTINGS_FILE = Path(
+    os.getenv(
+        "PLAYLIST_PILOT_SETTINGS_FILE",
+        Path(__file__).resolve().parent / "settings.json",
+    )
+)
 """
 Path to the local JSON file where application settings are stored.
 """

--- a/core/constants.py
+++ b/core/constants.py
@@ -1,13 +1,19 @@
 """
 Centralized constants for Playlist Pilot
 """
+import os
 from pathlib import Path
 
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 USER_DATA_DIR = BASE_DIR / "user_data"
 # Match the location used in `config.py` so settings are read from the same file
-SETTINGS_FILE = Path("/app/settings.json")
+SETTINGS_FILE = Path(
+    os.getenv(
+        "PLAYLIST_PILOT_SETTINGS_FILE",
+        Path(__file__).resolve().parent.parent / "settings.json",
+    )
+)
 CACHE_DIR = BASE_DIR / "cache"
 LOG_FILE = BASE_DIR / "logs" / "playlist_pilot.log"
 


### PR DESCRIPTION
## Summary
- make the settings file location configurable via `PLAYLIST_PILOT_SETTINGS_FILE`
- update constants to use the same environment variable

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d0da843888332bf95656a3fe15cfa