### PR TITLE
Clarify settings file requirement for Docker

### DIFF
--- a/Docs/docker_compose_installation.md
+++ b/Docs/docker_compose_installation.md
@@ -20,6 +20,10 @@ Follow these steps to run **Playlist Pilot** using Docker Compose.
    This file controls where logs, cache and other data are stored and can hold
    your API keys. The provided `docker-compose.yml` uses these variables for
    volume mounts so you can keep data anywhere you like.
+   Ensure the path specified by `SETTINGS_PATH` already exists as a file.
+   If the file is missing Docker will create a directory with that name and
+   Playlist Pilot will be unable to load its configuration. Create the file
+   manually with `touch /path/to/settings.json` before starting the container.
 3. **Build and start the containers**
    ```bash
    docker compose up --build -d

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ See [Docs/architecture.md](Docs/architecture.md) for a high level overview of th
 Copy `env.example` to `.env` and update the paths for your machine. Docker
 Compose will read this file and mount the specified directories and
 `settings.json` into the container.
+Make sure the path you set for `SETTINGS_PATH` points to an **existing file**.
+If the file does not exist Docker will create a directory with that name,
+which causes the application to fail. You can create a blank file beforehand
+with `touch /path/to/settings.json`.
 
 Use Docker Compose to build and start the app:
 

--- a/env.example
+++ b/env.example
@@ -8,6 +8,8 @@ LOGS_DIR=./logs
 CACHE_DIR=./cache
 USER_DATA_DIR=./user_data
 # Path to your settings file
+# The file must exist or Docker will create a directory instead of a file
+# which prevents the app from loading settings
 SETTINGS_PATH=/path/to/settings.json
 # Location of your music library
 MUSIC_DIR=/mnt/Music


### PR DESCRIPTION
## Summary
- clarify that `SETTINGS_PATH` must point to an existing file
- explain how to create the file in the README and Docker docs
- add reminder comment in `env.example`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d101baff883329c2ecc29c9e1920c