### PR TITLE
Fix unused import in tests

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,5 @@
 """Tests for the configuration helper functions."""
 
-from pathlib import Path
 
 import config
 


### PR DESCRIPTION
## Summary
- clean up unused Path import in `test_config`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'core')*
- `pip install pylint` *(fails: Could not find a version)*

------
https://chatgpt.com/codex/tasks/task_e_687d127a0dd8833297506f98bce096e9