### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,6 +2,8 @@ name: Pylint
 
 on: [push]
 
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/EoghannIrving/playlist-pilot/security/code-scanning/1](https://github.com/EoghannIrving/playlist-pilot/security/code-scanning/1)

To fix the issue, an explicit `permissions` block should be added to the root of the workflow file or within the specific job requiring permissions. This block will restrict the `GITHUB_TOKEN` to read-only permissions for repository contents, which is sufficient for the tasks performed in this workflow (e.g., running linting and tests).

The fix involves:
1. Adding a `permissions` block at the top level of the workflow file to enforce minimal permissions globally.
2. Setting `contents: read` explicitly, as this workflow does not require write access.

No additional dependencies, imports, or definitions are needed for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
