### PR TITLE
Fix empty track summary crash

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -3,17 +3,7 @@
 This file documents notable bugs discovered during a code audit.
 
 ## 1. Incorrect average popularity calculation
-`core/analysis.py` computes `avg_popularity` by dividing the sum of known popularity scores by `len(tracks)`. If some tracks lack a `combined_popularity` value the denominator still includes them which underestimates the average.
-
-Relevant code:
-```
-    base_summary = {
-        ...
-        "avg_listeners": mean([t.get("popularity", 0) for t in tracks]),
-        "avg_popularity": sum(popularity_values) / len(tracks),
-    }
-```
-【F:core/analysis.py†L69-L81】
+*Fixed.* `avg_popularity` now divides by the number of popularity values present and returns ``0`` when none exist.
 
 ## 2. History directory not created
 `save_user_history` writes to `USER_DATA_DIR`, but the directory is never ensured to exist. Attempting to save history on a clean install fails with `FileNotFoundError`.
@@ -28,13 +18,7 @@ Code reference:
 【F:core/history.py†L45-L67】
 
 ## 3. Crash when summarizing an empty track list
-`summarize_tracks` calls `mean` on an empty sequence when no tracks are provided which raises `StatisticsError`.
-
-Relevant line:
-```
-    "avg_listeners": mean([t.get("popularity", 0) for t in tracks]),
-```
-【F:core/analysis.py†L69-L80】
+*Fixed.* The function now falls back to ``0`` for ``avg_listeners`` and ``avg_popularity`` when no tracks are supplied.
 
 ## 4. Artist names not normalized in Jellyfin metadata search
 `fetch_jellyfin_track_metadata` cleans the item artist names but compares them to the raw `artist` parameter. Special quotes or punctuation can prevent matches.

--- a/core/analysis.py
+++ b/core/analysis.py
@@ -66,6 +66,11 @@ def summarize_tracks(tracks: List[dict]) -> dict:
         if t.get("combined_popularity") is not None
     ]
 
+    listener_values = [
+        t.get("popularity", 0) or 0
+        for t in tracks
+        if isinstance(t.get("popularity"), (int, float))
+    ]
     base_summary = {
         "dominant_genre": most_common(genres),
         "mood_profile": percent_distribution(moods),
@@ -76,8 +81,12 @@ def summarize_tracks(tracks: List[dict]) -> dict:
         "genre_distribution": percent_distribution(genres),
         "mood_distribution": percent_distribution(moods),
         "tempo_ranges": classify_tempo_ranges(tracks),
-        "avg_listeners": mean([t.get("popularity", 0) for t in tracks]),
-        "avg_popularity": sum(popularity_values) / len(tracks),
+        "avg_listeners": mean(listener_values) if listener_values else 0,
+        "avg_popularity": (
+            sum(popularity_values) / len(popularity_values)
+            if popularity_values
+            else 0
+        ),
     }
 
     base_summary["outliers"] = detect_outliers(tracks, base_summary)

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -51,3 +51,10 @@ def test_summarize_tracks_basic():
     assert summary["dominant_genre"] == "rock"
     assert summary["tempo_avg"] == 123
     assert summary["avg_popularity"] == 65
+
+
+def test_summarize_tracks_empty_list():
+    """Summarizing an empty list should return zeros without error."""
+    summary = summarize_tracks([])
+    assert summary["avg_listeners"] == 0
+    assert summary["avg_popularity"] == 0


### PR DESCRIPTION
## Summary
- prevent crash when summarizing empty track lists
- test that summarizing an empty list returns zeros
- mark related bugs as fixed in BUGS.md

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d1d803b4c833288605e8751a909b2