### PR TITLE
Handle invalid JSON from GetSongBPM API

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -499,7 +499,17 @@ async def test_getsongbpm(request: Request):
                 headers=settings.getsongbpm_headers,
                 timeout=settings.http_timeout_short,
             )
-        json_data = r.json()
+        try:
+            json_data = r.json()
+        except ValueError as exc:  # json.JSONDecodeError inherits from ValueError
+            logger.error("JSON decode error during GetSongBPM API test: %s", str(exc))
+            return JSONResponse(
+                {
+                    "success": False,
+                    "status": r.status_code,
+                    "error": "Invalid JSON response from GetSongBPM.",
+                }
+            )
         valid = r.status_code == 200 and "search" in json_data
         return JSONResponse(
             {"success": valid, "status": r.status_code, "data": json_data}


### PR DESCRIPTION
## Summary
- make `/api/test/getsongbpm` robust against invalid JSON

## Testing
- `black .`
- `PYTHONPATH=$PWD pytest -q`
- ❌ `pip install -r requirements.txt` (fails due to no internet)
- ❌ `pylint core api services utils` (pylint not installed)

------
https://chatgpt.com/codex/tasks/task_e_687d32ae7ed483329ee4abda7af5a2dc