### PR TITLE
Fix history save path creation

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -6,7 +6,9 @@ This file documents notable bugs discovered during a code audit.
 *Fixed.* `avg_popularity` now divides by the number of popularity values present and returns ``0`` when none exist.
 
 ## 2. History directory not created
-`save_user_history` writes to `USER_DATA_DIR`, but the directory is never ensured to exist. Attempting to save history on a clean install fails with `FileNotFoundError`.
+*Fixed.* The user history directory is now created automatically before writing files.
+
+`save_user_history` writes to `USER_DATA_DIR`, but the directory was never ensured to exist. Attempting to save history on a clean install failed with `FileNotFoundError`.
 
 Code reference:
 ```
@@ -15,7 +17,7 @@ Code reference:
     with open(history_file, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2)
 ```
-【F:core/history.py†L45-L67】
+【F:core/history.py†L45-L71】
 
 ## 3. Crash when summarizing an empty track list
 *Fixed.* The function now falls back to ``0`` for ``avg_listeners`` and ``avg_popularity`` when no tracks are supplied.

--- a/core/history.py
+++ b/core/history.py
@@ -33,6 +33,7 @@ def user_history_path(user_id: str) -> Path:
     """Constructs the path to the user's history file."""
     return USER_DATA_DIR / f"{user_id}.json"
 
+
 def save_user_history(user_id: str, label: str, suggestions: list[dict]) -> None:
     """
     Append a new labeled suggestion set to a user's history file.
@@ -43,6 +44,8 @@ def save_user_history(user_id: str, label: str, suggestions: list[dict]) -> None
         suggestions (list[dict]): Validated suggestions from GPT
     """
     history_file = user_history_path(user_id)
+    # Ensure the user data directory exists before writing
+    history_file.parent.mkdir(parents=True, exist_ok=True)
 
     if os.path.exists(history_file):
         try:
@@ -56,10 +59,7 @@ def save_user_history(user_id: str, label: str, suggestions: list[dict]) -> None
     else:
         data = []
 
-    data.append({
-        "label": label,
-        "suggestions": suggestions
-    })
+    data.append({"label": label, "suggestions": suggestions})
 
     try:
         with open(history_file, "w", encoding="utf-8") as f:
@@ -67,6 +67,7 @@ def save_user_history(user_id: str, label: str, suggestions: list[dict]) -> None
         logger.debug("History saved to %s", history_file)
     except (OSError, TypeError) as exc:
         logger.error("Failed to write history for %s: %s", user_id, exc)
+
 
 def load_user_history(user_id: str) -> list[dict]:
     """
@@ -89,6 +90,7 @@ def load_user_history(user_id: str) -> list[dict]:
         logger.warning("⚠️ Could not load history: %s", exc)
         return []
 
+
 def save_whole_user_history(user_id: str, history: list[dict]) -> None:
     """
     Overwrite a user's entire history file.
@@ -98,6 +100,8 @@ def save_whole_user_history(user_id: str, history: list[dict]) -> None:
         history (list[dict]): The full history to save
     """
     history_file = user_history_path(user_id)
+    # Ensure the user data directory exists before writing
+    history_file.parent.mkdir(parents=True, exist_ok=True)
     with open(history_file, "w", encoding="utf-8") as f:
         json.dump(history, f, indent=2)
     logger.debug("History saved to %s", history_file)


### PR DESCRIPTION
## Summary
- ensure the user history directory exists before saving
- mark bug 2 as fixed in BUGS.md

## Testing
- `black core/history.py`
- `pylint core/history.py` *(fails: command not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'config')*

------
https://chatgpt.com/codex/tasks/task_e_687d3477a7f0833292a0a916ef1ce044