### PR TITLE
Fix playlist analysis track fetch

### DIFF
--- a/services/jellyfin.py
+++ b/services/jellyfin.py
@@ -114,15 +114,13 @@ async def fetch_tracks_for_playlist_id(playlist_id: str) -> list[dict]:
     Reads .lrc files directly from disk if present,
     otherwise attempts Jellyfin Lyrics API fetch if HasLyrics is true.
     """
-    url = f"{settings.jellyfin_url}/Users/{settings.jellyfin_user_id}/Items"
+    url = f"{settings.jellyfin_url}/Playlists/{playlist_id}/Items"
     params = {
-        "ParentId": playlist_id,
-        "IncludeItemTypes": "Audio",
+        "UserId": settings.jellyfin_user_id,
         "Fields": (
             "Name,AlbumArtist,Artists,Album,ProductionYear,PremiereDate,"
             "Genres,RunTimeTicks,Genres,UserData,HasLyrics,Path,Tags"
         ),
-        "Recursive": True,
         "api_key": settings.jellyfin_api_key,
     }
 


### PR DESCRIPTION
## Summary
- fix Jellyfin playlist track lookup for analysis

## Testing
- `black .`
- `pylint core api services utils` *(fails: command not found)*
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_687d41253e648332b89f8754d70d3add