### PR TITLE
Fix lyrics parsing for tracks

### DIFF
--- a/core/playlist.py
+++ b/core/playlist.py
@@ -203,6 +203,7 @@ def normalize_track(raw: str | dict) -> Track:
     if isinstance(raw, dict):
         # Jellyfin track dict
         tempo = extract_tag_value(raw.get("Tags"), "tempo")
+        lyrics = raw.get("lyrics")
         return Track(
             raw=raw.get("Name", ""),
             title=raw.get("Name", "").strip(),
@@ -210,7 +211,7 @@ def normalize_track(raw: str | dict) -> Track:
             album=raw.get("Album", "").strip(),
             year=extract_year(raw),
             Genres=raw.get("Genres", []),
-            lyrics=raw.get("lyrics", []),
+            lyrics=lyrics,
             tempo=tempo,
             RunTimeTicks=raw.get("RunTimeTicks", 0),
         )


### PR DESCRIPTION
## Summary
- fix `lyrics` field parsing for Jellyfin tracks

## Testing
- `black .`
- `pylint core api services utils`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687d49128dc483328d24d73d634236d7