### PR TITLE
Fix tempo argument duplication

### DIFF
--- a/core/playlist.py
+++ b/core/playlist.py
@@ -312,8 +312,10 @@ async def enrich_track(parsed: Track | dict) -> EnrichedTrack:
     decade = infer_decade(final_year)
     mood, confidence = await _classify_mood(parsed, lastfm["tags"], bpm_data)
 
+    base_data = parsed.dict(exclude={"tempo", "jellyfin_play_count"})
+
     return EnrichedTrack(
-        **parsed.dict(),
+        **base_data,
         genre=genre or "Unknown",
         mood=mood,
         mood_confidence=round(confidence, 2),


### PR DESCRIPTION
## Summary
- prevent duplicate keyword arguments when creating `EnrichedTrack`

## Testing
- `pylint core api services utils`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687d4aa0e0a883329f6e95e10b5d14b9