### PR TITLE
Fix album duplication in track enrichment

### DIFF
--- a/core/playlist.py
+++ b/core/playlist.py
@@ -312,7 +312,7 @@ async def enrich_track(parsed: Track | dict) -> EnrichedTrack:
     decade = infer_decade(final_year)
     mood, confidence = await _classify_mood(parsed, lastfm["tags"], bpm_data)
 
-    base_data = parsed.dict(exclude={"tempo", "jellyfin_play_count"})
+    base_data = parsed.dict(exclude={"tempo", "jellyfin_play_count", "album"})
 
     return EnrichedTrack(
         **base_data,


### PR DESCRIPTION
## Summary
- handle album argument duplication in `enrich_track`

## Testing
- `pylint core api services utils --exit-zero`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_687d4bef3b64833285c38c59332f3b9a