### PR TITLE
Fix playlist analysis showing single track

### DIFF
--- a/core/playlist.py
+++ b/core/playlist.py
@@ -492,10 +492,12 @@ def extract_year_from_string(releasedate: str) -> str:
     return match.group(0) if match else ""
 
 
-async def enrich_jellyfin_playlist(playlist_id: str, limit: int = 10) -> list[dict]:
+async def enrich_jellyfin_playlist(
+    playlist_id: str, limit: int | None = None
+) -> list[dict]:
     """Fetch tracks for a playlist and enrich them concurrently."""
-    raw_tracks = await fetch_tracks_for_playlist_id(playlist_id)
-    if limit:
+    raw_tracks = await fetch_tracks_for_playlist_id(playlist_id, limit)
+    if isinstance(limit, int) and limit > 0:
         raw_tracks = raw_tracks[:limit]
 
     async def process(track: dict) -> dict | None:

--- a/services/jellyfin.py
+++ b/services/jellyfin.py
@@ -107,7 +107,9 @@ async def jf_get(path, **params):
         return {"error": str(exc)}
 
 
-async def fetch_tracks_for_playlist_id(playlist_id: str) -> list[dict]:
+async def fetch_tracks_for_playlist_id(
+    playlist_id: str, limit: int | None = None
+) -> list[dict]:
     """
     Fetch detailed track list for a given Jellyfin playlist ID.
     Includes expanded fields useful for enrichment and analysis.
@@ -123,6 +125,8 @@ async def fetch_tracks_for_playlist_id(playlist_id: str) -> list[dict]:
         ),
         "api_key": settings.jellyfin_api_key,
     }
+    if isinstance(limit, int) and limit > 0:
+        params["Limit"] = limit
 
     try:
         async with httpx.AsyncClient() as client:


### PR DESCRIPTION
## Summary
- fetch the entire playlist by allowing an optional limit in `fetch_tracks_for_playlist_id`
- pass the limit through `enrich_jellyfin_playlist` so analysis includes all items

## Testing
- `pylint core api services utils`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d4d6d60608332af0db347a4e59172