### PR TITLE
Add markdown stripping for GPT output

### DIFF
--- a/tests/test_text_utils.py
+++ b/tests/test_text_utils.py
@@ -1,0 +1,16 @@
+import utils.text_utils as tu
+
+
+def test_strip_markdown_basic():
+    text = "# Title\n- item1\n1. item2\n**bold** _italic_ [link](http://x.com)"
+    cleaned = tu.strip_markdown(text)
+    assert "#" not in cleaned
+    assert "*" not in cleaned
+    assert "_" not in cleaned
+    assert "[" not in cleaned
+    assert "Title" in cleaned
+    assert "item1" in cleaned
+    assert "item2" in cleaned
+    assert "bold" in cleaned
+    assert "italic" in cleaned
+    assert "link" in cleaned

--- a/utils/text_utils.py
+++ b/utils/text_utils.py
@@ -5,6 +5,32 @@
 import re
 
 
+def strip_markdown(text: str) -> str:
+    """Remove common Markdown formatting from ``text``."""
+
+    # Code blocks
+    text = re.sub(r"```.*?```", "", text, flags=re.DOTALL)
+    # Images
+    text = re.sub(r"!\[[^\]]*\]\([^\)]*\)", "", text)
+    # Links
+    text = re.sub(r"\[([^\]]+)\]\([^\)]+\)", r"\1", text)
+    # Inline code
+    text = re.sub(r"`{1,3}([^`]*)`{1,3}", r"\1", text)
+    # Bold/italic/strikethrough
+    text = re.sub(r"(\*\*|__)(.*?)\1", r"\2", text)
+    text = re.sub(r"(\*|_)(.*?)\1", r"\2", text)
+    text = re.sub(r"~~(.*?)~~", r"\1", text)
+    # Headings
+    text = re.sub(r"^#{1,6}\s*", "", text, flags=re.MULTILINE)
+    # Blockquotes
+    text = re.sub(r"^>\s?", "", text, flags=re.MULTILINE)
+    # Lists
+    text = re.sub(r"^\s*[-*+]\s+", "", text, flags=re.MULTILINE)
+    text = re.sub(r"^\s*\d+\.\s+", "", text, flags=re.MULTILINE)
+
+    return text.strip()
+
+
 def clean(text: str) -> str:
     """Normalize text by lowercasing and removing punctuation."""
     return re.sub(r"[^\w\s]", "", text.lower().strip())


### PR DESCRIPTION
## Summary
- implement `strip_markdown` helper in `utils.text_utils`
- clean GPT responses using `strip_markdown`
- test the new helper

## Testing
- `black .`
- `pylint core api services utils`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_687d5a6502608332b0c5574d16961e06