### PR TITLE
Fix extract_year fallback

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -63,11 +63,15 @@ async def get_cached_playlists(user_id: str | None = None) -> dict:
 【F:core/m3u.py†L74-L86】
 
 ## 7. `extract_year` can return the string "None"
-`extract_year` converts the `ProductionYear` value to a string before using `or` to fall back to `PremiereDate`. When `ProductionYear` is `None`, the string "None" is returned instead of the premiere year.
+*Fixed.* The function now checks the ``ProductionYear`` value before converting to a string and only falls back to ``PremiereDate`` when it's missing.
 ```
-    return str(track.get("ProductionYear")) or str(track.get("PremiereDate", "")[:4])
+    prod_year = track.get("ProductionYear")
+    if prod_year:
+        return str(prod_year)
+    premiere = track.get("PremiereDate", "")
+    return str(premiere)[:4] if premiere else ""
 ```
-【F:core/playlist.py†L310-L315】
+【F:core/playlist.py†L342-L350】
 
 ## 8. `_determine_year` returns mixed types
 This helper claims to return `int | None` for the year, but actually returns a string when only the Jellyfin year is available.

--- a/core/models.py
+++ b/core/models.py
@@ -1,7 +1,8 @@
 """Data models for playlist-pilot."""
 
 from typing import List, Optional
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field  # pylint: disable=no-name-in-module
+
 
 class Track(BaseModel):
     """Normalized track metadata."""
@@ -19,7 +20,9 @@ class Track(BaseModel):
 
     class Config:  # pylint: disable=too-few-public-methods
         """Pydantic configuration for ``Track`` model."""
+
         extra = "allow"
+
 
 class EnrichedTrack(Track):
     """Track metadata after enrichment."""
@@ -37,6 +40,7 @@ class EnrichedTrack(Track):
 
     class Config:  # pylint: disable=too-few-public-methods
         """Pydantic configuration for ``EnrichedTrack`` model."""
+
         extra = "allow"
 
 

--- a/core/playlist.py
+++ b/core/playlist.py
@@ -342,9 +342,11 @@ def infer_decade(year_str: str) -> str:
 def extract_year(track: dict) -> str:
     """Extract the production year from a Jellyfin track dict."""
     try:
-        return str(track.get("ProductionYear")) or str(
-            track.get("PremiereDate", "")[:4]
-        )
+        prod_year = track.get("ProductionYear")
+        if prod_year:
+            return str(prod_year)
+        premiere = track.get("PremiereDate", "")
+        return str(premiere)[:4] if premiere else ""
     except (AttributeError, TypeError):
         return ""
 

--- a/tests/test_playlist.py
+++ b/tests/test_playlist.py
@@ -1,0 +1,32 @@
+"""Tests for helper functions in ``core.playlist``."""
+
+import ast
+from pathlib import Path
+
+
+def _load_extract_year():
+    """Load the ``extract_year`` function from ``core.playlist`` without importing the module."""
+    src = Path("core/playlist.py").read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    func = next(
+        n
+        for n in tree.body
+        if isinstance(n, ast.FunctionDef) and n.name == "extract_year"
+    )
+    module = ast.Module(body=[func], type_ignores=[])
+    ns = {}
+    exec(compile(module, filename="<extract_year>", mode="exec"), ns)
+    return ns["extract_year"]
+
+
+extract_year = _load_extract_year()
+
+
+def test_extract_year_fallback_to_premiere():
+    track = {"ProductionYear": None, "PremiereDate": "2023-05-01T00:00:00Z"}
+    assert extract_year(track) == "2023"
+
+
+def test_extract_year_production_year_used():
+    track = {"ProductionYear": 1999, "PremiereDate": "2020-01-01"}
+    assert extract_year(track) == "1999"


### PR DESCRIPTION
## Summary
- handle None values in `extract_year`
- silence pylint import error for pydantic
- add regression tests for `extract_year`
- document fix in BUGS.md

## Testing
- `pylint core api services utils`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_687d5b336c148332aa4c9ed53ed461ca