### PR TITLE
Fix history date regex

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -154,11 +154,11 @@ The delete route filters history entries by label string. If multiple entries sh
 【F:api/routes.py†L281-L291】
 
 ## 16. Extra hyphen breaks date extraction
-`extract_date_from_label` uses a greedy regex and fails when the playlist label contains another " - " before the timestamp.
+*Fixed.* `extract_date_from_label` now matches only the final timestamp segment.
 ```
-    match = re.search(r"- (.+)$", label)
+    match = re.search(r"- (\d{4}-\d{2}-\d{2} \d{2}:\d{2})$", label)
 ```
-【F:core/history.py†L21-L30】
+【F:core/history.py†L21-L32】
 
 ## 17. Jellyfin playlist comparison uses nonexistent artist field
 `compare_playlists_form` looks for `Artist` on each Jellyfin track, but the API provides an `Artists` list. Artist names end up blank during comparison.

--- a/core/history.py
+++ b/core/history.py
@@ -20,7 +20,7 @@ logger = logging.getLogger("playlist-pilot")
 
 def extract_date_from_label(label: str) -> datetime:
     """Extract a datetime object from a history label string."""
-    match = re.search(r"- (.+)$", label)
+    match = re.search(r"- (\d{4}-\d{2}-\d{2} \d{2}:\d{2})$", label)
     if match:
         try:
             return datetime.strptime(match.group(1), "%Y-%m-%d %H:%M")

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,0 +1,13 @@
+from datetime import datetime
+
+from core.history import extract_date_from_label
+
+
+def test_extract_date_from_label_extra_hyphen():
+    label = "Favorites - Smooth - 2023-09-30 12:00"
+    assert extract_date_from_label(label) == datetime(2023, 9, 30, 12, 0)
+
+
+def test_extract_date_from_label_invalid():
+    label = "No Date"
+    assert extract_date_from_label(label) == datetime.min


### PR DESCRIPTION
## Summary
- handle extra hyphen in `extract_date_from_label`
- cover the fix with tests
- mark the issue resolved in BUGS.md

## Testing
- `pylint core api services utils`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_687d6a64563c8332a5bca2cc8a18fe1a