### PR TITLE
Fix test lint warnings

### DIFF
--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,13 +1,17 @@
+"""Tests for helpers in ``core.history``."""
+
 from datetime import datetime
 
 from core.history import extract_date_from_label
 
 
 def test_extract_date_from_label_extra_hyphen():
+    """Handle labels with an extra hyphen section."""
     label = "Favorites - Smooth - 2023-09-30 12:00"
     assert extract_date_from_label(label) == datetime(2023, 9, 30, 12, 0)
 
 
 def test_extract_date_from_label_invalid():
+    """Return ``datetime.min`` for labels without dates."""
     label = "No Date"
     assert extract_date_from_label(label) == datetime.min

--- a/tests/test_playlist.py
+++ b/tests/test_playlist.py
@@ -15,7 +15,9 @@ def _load_extract_year():
     )
     module = ast.Module(body=[func], type_ignores=[])
     ns = {}
-    exec(compile(module, filename="<extract_year>", mode="exec"), ns)
+    exec(
+        compile(module, filename="<extract_year>", mode="exec"), ns
+    )  # pylint: disable=exec-used
     return ns["extract_year"]
 
 
@@ -23,10 +25,12 @@ extract_year = _load_extract_year()
 
 
 def test_extract_year_fallback_to_premiere():
+    """Fallback to ``PremiereDate`` when ``ProductionYear`` is missing."""
     track = {"ProductionYear": None, "PremiereDate": "2023-05-01T00:00:00Z"}
     assert extract_year(track) == "2023"
 
 
 def test_extract_year_production_year_used():
+    """Use ``ProductionYear`` when present."""
     track = {"ProductionYear": 1999, "PremiereDate": "2020-01-01"}
     assert extract_year(track) == "1999"

--- a/tests/test_text_utils.py
+++ b/tests/test_text_utils.py
@@ -1,7 +1,10 @@
+"""Tests for helpers in ``utils.text_utils``."""
+
 import utils.text_utils as tu
 
 
 def test_strip_markdown_basic():
+    """Remove common markdown characters from text."""
     text = "# Title\n- item1\n1. item2\n**bold** _italic_ [link](http://x.com)"
     cleaned = tu.strip_markdown(text)
     assert "#" not in cleaned


### PR DESCRIPTION
## Summary
- add documentation strings for history and text utils tests
- embed docstrings in playlist test and suppress exec linter warning

## Testing
- `pylint core api services utils`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_687d6c1f5d748332bd5a5acb27b8b500