### PR TITLE
Fix pylint exec warning

### DIFF
--- a/tests/test_playlist.py
+++ b/tests/test_playlist.py
@@ -15,9 +15,9 @@ def _load_extract_year():
     )
     module = ast.Module(body=[func], type_ignores=[])
     ns = {}
-    exec(
+    exec(  # pylint: disable=exec-used
         compile(module, filename="<extract_year>", mode="exec"), ns
-    )  # pylint: disable=exec-used
+    )
     return ns["extract_year"]
 
 


### PR DESCRIPTION
## Summary
- inline pylint disable comment for exec usage in tests

## Testing
- `pylint core api services utils`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d6ed54eac83329b12db218d1fc575