### PR TITLE
Fix playlist cache user id bug

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -37,7 +37,7 @@ Snippet:
 【F:services/jellyfin.py†L247-L253】
 
 ## 5. `get_cached_playlists` ignores supplied user id
-`utils/helpers.py` accepts an optional `user_id` but always calls `fetch_audio_playlists()` which fetches playlists for the default user. Passing a different user id only changes the cache key, not the data fetched.
+*Fixed.* `fetch_audio_playlists` now accepts a `user_id` argument and `get_cached_playlists` forwards the provided value so the correct user's playlists are fetched.
 
 Code:
 ```
@@ -46,7 +46,7 @@ async def get_cached_playlists(user_id: str | None = None) -> dict:
     cache_key = f"playlists:{user_id}"
     playlists_data = playlist_cache.get(cache_key)
     if playlists_data is None:
-        playlists_data = await fetch_audio_playlists()
+        playlists_data = await fetch_audio_playlists(user_id)
         playlist_cache.set(cache_key, playlists_data, expire=CACHE_TTLS["playlists"])
     return playlists_data
 ```

--- a/core/playlist.py
+++ b/core/playlist.py
@@ -42,10 +42,11 @@ from utils.cache_manager import library_cache, CACHE_TTLS
 logger = logging.getLogger("playlist-pilot")
 
 
-async def fetch_audio_playlists() -> dict:
+async def fetch_audio_playlists(user_id: str | None = None) -> dict:
     """Fetch all playlists that contain at least one audio track."""
+    user_id = user_id or settings.jellyfin_user_id
     resp = await jf_get(
-        f"/Users/{settings.jellyfin_user_id}/Items",
+        f"/Users/{user_id}/Items",
         IncludeItemTypes="Playlist",
         Recursive="true",
     )
@@ -57,7 +58,7 @@ async def fetch_audio_playlists() -> dict:
     for pl in playlists:
         pl_id = pl["Id"]
         contents_resp = await jf_get(
-            f"/Users/{settings.jellyfin_user_id}/Items",
+            f"/Users/{user_id}/Items",
             ParentId=pl_id,
             IncludeItemTypes="Audio",
             Recursive="true",

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -21,7 +21,7 @@ async def get_cached_playlists(user_id: str | None = None) -> dict:
     playlists_data = playlist_cache.get(cache_key)
     if playlists_data is None:
         try:
-            playlists_data = await fetch_audio_playlists()
+            playlists_data = await fetch_audio_playlists(user_id)
         except Exception as exc:  # pylint: disable=broad-exception-caught
             logger.error("Failed to fetch playlists: %s", exc)
             playlists_data = {"playlists": [], "error": str(exc)}


### PR DESCRIPTION
## Summary
- ensure `fetch_audio_playlists` accepts a user id
- pass user id through `get_cached_playlists`
- document the fix in BUGS.md

## Testing
- `black .`
- `pylint core api services utils`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d712da4fc83328a44c5cfbb39c6bc