### PR TITLE
Add mypy CI and expand checks

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,4 +1,4 @@
-name: Pytest
+name: Mypy
 
 on:
   push:
@@ -8,7 +8,7 @@ permissions:
   contents: read
 
 jobs:
-  test:
+  type-check:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -23,8 +23,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pytest pytest-cov
+          pip install mypy
       - name: Set PYTHONPATH
         run: echo "PYTHONPATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV
-      - name: Run tests
-        run: pytest --cov=. --cov-report=term-missing:skip-covered --cov-fail-under=25
+      - name: Run mypy
+        run: mypy . --ignore-missing-imports

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,6 +1,8 @@
 name: Pylint
 
-on: [push]
+on:
+  push:
+  pull_request:
 
 permissions:
   contents: read
@@ -29,4 +31,4 @@ jobs:
       run: pylint $(git ls-files '*.py')
     - name: Run tests
       # Coverage is currently below 50%, so lower the fail-under threshold
-      run: pytest --cov=. --cov-report=term-missing:skip-covered --cov-fail-under=20
+      run: pytest --cov=. --cov-report=term-missing:skip-covered --cov-fail-under=25


### PR DESCRIPTION
## Summary
- trigger linting CI on pull requests
- tighten coverage requirement to 25%
- add a new workflow running `mypy`

## Testing
- `pylint core api services utils`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687d79a6824c8332a725a1ea018bbb22