### PR TITLE
Ensure Python 3.10 compatibility

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/Docs/local_installation.md
+++ b/Docs/local_installation.md
@@ -1,6 +1,6 @@
 # Local Installation
 
-You can run Playlist Pilot without Docker by installing the Python requirements and running the app directly.
+You can run Playlist Pilot without Docker by installing the Python requirements and running the app directly. Playlist Pilot supports **Python 3.10 and above**.
 
 1. **Clone the repo** and install dependencies:
    ```bash

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ See [Docs/architecture.md](Docs/architecture.md) for a high level overview of th
 
 ## Requirements
 
-- Python 3.11+
+- Python 3.10+
 - `pip install -r requirements.txt` or use Docker
 - Run tests with `pytest`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "FastAPI application for playlist generation and management"
 authors = [{name = "Playlist Pilot Team"}]
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 license = {file = "LICENSE"}
 dependencies = [
     "aiofiles",


### PR DESCRIPTION
## Summary
- lower python requirement to 3.10
- update docs to mention Python 3.10+
- run CI on Python 3.10, 3.11 and 3.12

## Testing
- `black .`
- `pylint core api services utils`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687e18cc63a88332a0e2bed578f841a9