### PR TITLE
Fix mypy errors in playlist and GPT modules

### DIFF
--- a/core/analysis.py
+++ b/core/analysis.py
@@ -125,7 +125,11 @@ def detect_outliers(tracks: List[dict], summary: dict) -> List[dict]:
 
         # Genre mismatch (excluding 'Unknown')
         genre = t.get("genre")
-        if isinstance(genre, str) and genre.lower() != dominant_genre.lower():
+        if (
+            isinstance(genre, str)
+            and isinstance(dominant_genre, str)
+            and genre.lower() != dominant_genre.lower()
+        ):
             reasons.append("genre")
 
         # Mood unknown or missing confidence

--- a/core/playlist.py
+++ b/core/playlist.py
@@ -297,7 +297,9 @@ async def _classify_mood(
     tag_scores = mood_scores_from_lastfm_tags(tags)
     bpm_scores = mood_scores_from_bpm_data(bpm_data or {})
     lyrics = get_lyrics_for_enrich(parsed.dict())
-    lyrics_mood = await asyncio.to_thread(analyze_mood_from_lyrics, lyrics)
+    lyrics_mood = (
+        await asyncio.to_thread(analyze_mood_from_lyrics, lyrics) if lyrics else None
+    )
     lyrics_scores = build_lyrics_scores(lyrics_mood) if lyrics_mood else None
     return combine_mood_scores(tag_scores, bpm_scores, lyrics_scores)
 

--- a/services/gpt.py
+++ b/services/gpt.py
@@ -48,7 +48,7 @@ def describe_popularity(score: float) -> str:
 
 
 def _build_gpt_prompt(
-    existing_tracks: list[str], count: int, summary: dict | None = None
+    existing_tracks: list[str], count: int, summary: dict | str | None = None
 ) -> str:
     """
     Constructs a tailored GPT prompt based a user selected playlist.
@@ -334,7 +334,8 @@ async def generate_playlist_analysis_summary(summary: dict, tracks: list):
         temperature=0.7,
     )
 
-    content = response.choices[0].message.content.strip()
+    raw_content = response.choices[0].message.content or ""
+    content = raw_content.strip()
     content = strip_markdown(content)
 
     # Split output if needed


### PR DESCRIPTION
## Summary
- fix genre comparison in `detect_outliers`
- avoid passing `None` lyrics to the mood classifier
- broaden `_build_gpt_prompt` summary argument and guard GPT responses

## Testing
- `pylint core api services utils`
- `PYTHONPATH=. pytest`
- `mypy . --ignore-missing-imports`


------
https://chatgpt.com/codex/tasks/task_e_687e1c07db9c833284d2ce2b33e7eaca