### PR TITLE
Add .m3u round‑trip tests

### DIFF
--- a/tests/test_m3u.py
+++ b/tests/test_m3u.py
@@ -78,3 +78,69 @@ def test_infer_metadata_windows_path():
         r"C:\\Music\\Metallica\\Justice\\Metallica - One.mp3"
     )
     assert meta == {"title": "One", "artist": "Metallica"}
+
+
+import asyncio
+import importlib
+from pathlib import Path
+from core import constants
+from config import settings
+
+
+def _setup_roundtrip(monkeypatch, tmp_path, path_template):
+    monkeypatch.setattr(constants, "USER_DATA_DIR", tmp_path)
+    monkeypatch.setattr(settings, "jellyfin_user_id", "user", raising=False)
+    monkeypatch.setattr("tempfile.gettempdir", lambda: str(tmp_path))
+
+    services_stub = types.ModuleType("services.jellyfin")
+
+    async def dummy_resolve(title, artist, *_a, **_kw):
+        return Path(path_template.format(artist=title, title=artist)).as_posix()
+
+    async def dummy_search(*_a, **_kw):
+        return {"Id": "1"}
+
+    services_stub.resolve_jellyfin_path = dummy_resolve
+    services_stub.search_jellyfin_for_track = dummy_search
+    playlist_stub = types.ModuleType("core.playlist")
+
+    async def dummy_enrich(track):
+        return types.SimpleNamespace(**track, dict=lambda: track)
+
+    playlist_stub.enrich_track = dummy_enrich
+    monkeypatch.setitem(sys.modules, "services.jellyfin", services_stub)
+    monkeypatch.setitem(sys.modules, "core.playlist", playlist_stub)
+    sys.modules.pop("core.m3u", None)
+    sys.modules.pop("core.history", None)
+    m3u = importlib.import_module("core.m3u")
+    history = importlib.import_module("core.history")
+    return m3u, history
+
+
+def _roundtrip(monkeypatch, tmp_path, path_template):
+    m3u, history = _setup_roundtrip(monkeypatch, tmp_path, path_template)
+    entry = {
+        "suggestions": [
+            {"text": "Artist - Title", "in_jellyfin": True, "album": "Album"}
+        ]
+    }
+    loop = asyncio.get_event_loop()
+    m3u_file = loop.run_until_complete(
+        m3u.export_history_entry_as_m3u(entry, "url", "key")
+    )
+    loop.run_until_complete(m3u.import_m3u_as_history_entry(str(m3u_file)))
+    hist = history.load_user_history("user")
+    assert hist
+    track = hist[0]["suggestions"][0]
+    assert track["artist"] == "Artist"
+    assert track["title"] == "Title"
+
+
+def test_export_import_roundtrip_posix(monkeypatch, tmp_path):
+    """Playlists round-trip using POSIX paths."""
+    _roundtrip(monkeypatch, tmp_path, "/Music/{artist}/Album/{title}.mp3")
+
+
+def test_export_import_roundtrip_windows(monkeypatch, tmp_path):
+    """Playlists round-trip using Windows paths."""
+    _roundtrip(monkeypatch, tmp_path, r"C:\Music\{artist}\Album\{title}.mp3")


### PR DESCRIPTION
## Summary
- extend `tests/test_m3u.py` with full import/export coverage
- verify playlists export and import correctly using both POSIX and Windows paths

## Testing
- `pylint core api services utils`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687eadb4998883329874a554ec14a134