### PR TITLE
Add lyrics processing toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ See [Docs/architecture.md](Docs/architecture.md) for a high level overview of th
 - **BPM and audio data** from GetSongBPM to enrich mood scoring.
 - **Lyrics-based mood analysis** when `.lrc` files or Jellyfin lyrics are
   available.
+- **Toggle for lyrics processing** if you want to disable GPT lyric analysis.
 - **Customizable weights** for lyrics, BPM and tag matching to fine tune
   playlist mood detection.
 - **YouTube link lookup** via yt‑dlp for tracks not in Jellyfin.

--- a/api/forms.py
+++ b/api/forms.py
@@ -4,6 +4,7 @@ import json
 from fastapi import Form
 from config import AppSettings
 
+
 class SettingsForm(AppSettings):
     """Pydantic model for updating application settings via form."""
 
@@ -28,6 +29,7 @@ class SettingsForm(AppSettings):
         youtube_max_duration: int = Form(360),
         library_scan_limit: int = Form(1000),
         music_library_root: str = Form("Movies/Music"),
+        lyrics_enabled: bool = Form(False),
         lyrics_weight: float = Form(1.5),
         bpm_weight: float = Form(1.0),
         tags_weight: float = Form(0.7),
@@ -43,7 +45,9 @@ class SettingsForm(AppSettings):
             getsongbpm_api_key=getsongbpm_api_key,
             global_min_lfm=global_min_lfm,
             global_max_lfm=global_max_lfm,
-            cache_ttls=(json.loads(cache_ttls) if cache_ttls else AppSettings().cache_ttls),
+            cache_ttls=(
+                json.loads(cache_ttls) if cache_ttls else AppSettings().cache_ttls
+            ),
             getsongbpm_base_url=getsongbpm_base_url,
             getsongbpm_headers=(
                 json.loads(getsongbpm_headers)
@@ -56,6 +60,7 @@ class SettingsForm(AppSettings):
             youtube_max_duration=youtube_max_duration,
             library_scan_limit=library_scan_limit,
             music_library_root=music_library_root,
+            lyrics_enabled=lyrics_enabled,
             lyrics_weight=lyrics_weight,
             bpm_weight=bpm_weight,
             tags_weight=tags_weight,

--- a/api/routes.py
+++ b/api/routes.py
@@ -377,6 +377,7 @@ async def update_settings(
     settings.youtube_max_duration = form_data.youtube_max_duration
     settings.library_scan_limit = form_data.library_scan_limit
     settings.music_library_root = form_data.music_library_root
+    settings.lyrics_enabled = form_data.lyrics_enabled
     settings.lyrics_weight = form_data.lyrics_weight
     settings.bpm_weight = form_data.bpm_weight
     settings.tags_weight = form_data.tags_weight

--- a/config.py
+++ b/config.py
@@ -45,6 +45,7 @@ class AppSettings(BaseModel):
         openai_api_key (str): API key for OpenAI.
         lastfm_api_key (str): Optional key for Last.fm integration.
         model (str): GPT model to use (default is 'gpt-4o-mini').
+        lyrics_enabled (bool): Toggle for lyrics-based mood analysis.
     """
 
     jellyfin_url: str = ""
@@ -84,6 +85,7 @@ class AppSettings(BaseModel):
     youtube_max_duration: int = 360
     library_scan_limit: int = 1000
     music_library_root: str = "Movies/Music"
+    lyrics_enabled: bool = True
     lyrics_weight: float = 1.5
     bpm_weight: float = 1.0
     tags_weight: float = 0.7

--- a/core/playlist.py
+++ b/core/playlist.py
@@ -296,11 +296,15 @@ async def _classify_mood(
     logger.debug("Enriching track: %s", parsed.title)
     tag_scores = mood_scores_from_lastfm_tags(tags)
     bpm_scores = mood_scores_from_bpm_data(bpm_data or {})
-    lyrics = get_lyrics_for_enrich(parsed.dict())
-    lyrics_mood = (
-        await asyncio.to_thread(analyze_mood_from_lyrics, lyrics) if lyrics else None
-    )
-    lyrics_scores = build_lyrics_scores(lyrics_mood) if lyrics_mood else None
+    lyrics_scores = None
+    if settings.lyrics_enabled:
+        lyrics = get_lyrics_for_enrich(parsed.dict())
+        lyrics_mood = (
+            await asyncio.to_thread(analyze_mood_from_lyrics, lyrics)
+            if lyrics
+            else None
+        )
+        lyrics_scores = build_lyrics_scores(lyrics_mood) if lyrics_mood else None
     return combine_mood_scores(tag_scores, bpm_scores, lyrics_scores)
 
 

--- a/services/jellyfin.py
+++ b/services/jellyfin.py
@@ -192,6 +192,8 @@ async def fetch_lyrics_for_item(item_id: str) -> str | None:
 
 async def _attach_lyrics(item: dict) -> None:
     """Attach lyrics to a track dictionary if available."""
+    if not settings.lyrics_enabled:
+        return
     track_path = item.get("Path")
     if track_path:
         lrc_contents = read_lrc_for_track(track_path)

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -182,6 +182,10 @@
           <input type="text" id="MUSIC_LIBRARY_ROOT" name="music_library_root" value="{{ settings.music_library_root }}" class="w-full p-2 border border-gray-300 rounded dark:bg-gray-300 dark:text-black focus:ring-2 focus:ring-blue-500">
           <small class="text-gray-300">Path to your Jellyfin music library.</small>
         </div>
+        <div class="flex items-center space-x-2">
+          <input type="checkbox" id="LYRICS_ENABLED" name="lyrics_enabled" value="true" class="form-checkbox h-4 w-4 text-blue-600" {% if settings.lyrics_enabled %}checked{% endif %}>
+          <label for="LYRICS_ENABLED" class="font-semibold">Enable Lyrics Processing</label>
+        </div>
         <div class="space-y-4">
           <label for="LYRICS_WEIGHT" class="block font-semibold">Lyrics Weight</label>
           <input type="number" step="0.1" id="LYRICS_WEIGHT" name="lyrics_weight" value="{{ settings.lyrics_weight }}" class="w-full p-2 border border-gray-300 rounded dark:bg-gray-300 dark:text-black focus:ring-2 focus:ring-blue-500">


### PR DESCRIPTION
## Summary
- add `lyrics_enabled` field to settings and forms
- expose lyrics toggle in settings UI
- skip lyrics processing in Jellyfin service and mood classification when disabled
- document the toggle in the README

## Testing
- `black api/forms.py api/routes.py config.py core/playlist.py services/jellyfin.py`
- `pylint core api services utils`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687eaf44251c833295b5390cc73b9824