### PR TITLE
Fix pylint warnings in test_m3u

### DIFF
--- a/tests/test_m3u.py
+++ b/tests/test_m3u.py
@@ -1,6 +1,6 @@
 """Unit tests for M3U parsing utilities."""
 
-# pylint: disable=wrong-import-position
+# pylint: disable=wrong-import-order,wrong-import-position
 
 import asyncio
 import importlib


### PR DESCRIPTION
## Summary
- silence pylint wrong-import-order warnings in tests

## Testing
- `black tests/test_m3u.py`
- `pylint core api services utils`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687eb65f0c248332b5f79f9d79a85c90