### PR TITLE
Fix normalized artist match in Jellyfin metadata search

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -23,18 +23,18 @@ Code reference:
 *Fixed.* The function now falls back to ``0`` for ``avg_listeners`` and ``avg_popularity`` when no tracks are supplied.
 
 ## 4. Artist names not normalized in Jellyfin metadata search
-*Open.* `fetch_jellyfin_track_metadata` cleans the item artist names but compares them to the raw `artist` parameter. Special quotes or punctuation can prevent matches.
+*Fixed.* The search now normalizes the input `artist` value before comparison.
 
 Snippet:
 ```
     artists = [normalize_search_term(a) for a in artists_list]
     if (
         title_cleaned.lower() in name.lower()
-        and any(artist.lower() in a.lower() for a in artists)
+        and any(artist_cleaned.lower() in a.lower() for a in artists)
     ):
         ...
 ```
-【F:services/jellyfin.py†L247-L253】
+【F:services/jellyfin.py†L279-L285】
 
 ## 5. `get_cached_playlists` ignores supplied user id
 *Fixed.* `fetch_audio_playlists` now accepts a `user_id` argument and `get_cached_playlists` forwards the provided value so the correct user's playlists are fetched.

--- a/services/jellyfin.py
+++ b/services/jellyfin.py
@@ -251,6 +251,7 @@ async def fetch_jellyfin_track_metadata(title: str, artist: str) -> dict | None:
     Returns None if no match is found.
     """
     title_cleaned = normalize_search_term(title)
+    artist_cleaned = normalize_search_term(artist)
     try:
         async with httpx.AsyncClient() as client:
             response = await client.get(
@@ -280,7 +281,7 @@ async def fetch_jellyfin_track_metadata(title: str, artist: str) -> dict | None:
             artists_list = item.get("Artists", [])
             artists = [normalize_search_term(a) for a in artists_list]
             if title_cleaned.lower() in name.lower() and any(
-                artist.lower() in a.lower() for a in artists
+                artist_cleaned.lower() in a.lower() for a in artists
             ):
                 logger.debug("✅ Match found: %s by %s", name, artists)
                 return item


### PR DESCRIPTION
## Summary
- normalize the `artist` argument when querying Jellyfin track metadata
- mark bug #4 as fixed in `BUGS.md`

## Testing
- `black .`
- `pylint core api services utils`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_687eb9436d348332be04413ce1f9055f