### PR TITLE
Fix export playlist bug

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -53,14 +53,14 @@ async def get_cached_playlists(user_id: str | None = None) -> dict:
 【F:utils/helpers.py†L15-L23】
 
 ## 6. Title and artist swapped when exporting history playlists
-*Open.* `export_history_entry_as_m3u` assigns `title, artist = parse_track_text(...)` but `parse_track_text` returns `(artist, title)`. This reversal causes Jellyfin path lookups to use the wrong parameters.
+*Fixed.* The function now assigns the variables in the correct order before calling `resolve_jellyfin_path`.
 ```
     for track in entry.get("suggestions", []):
-        title, artist = parse_track_text(track["text"])
+        artist, title = parse_track_text(track["text"])
         ...
         path = await resolve_jellyfin_path(title, artist, jellyfin_url, jellyfin_api_key)
 ```
-【F:core/m3u.py†L74-L86】
+【F:core/m3u.py†L74-L88】
 
 ## 7. `extract_year` can return the string "None"
 *Fixed.* The function now checks the ``ProductionYear`` value before converting to a string and only falls back to ``PremiereDate`` when it's missing.

--- a/core/m3u.py
+++ b/core/m3u.py
@@ -76,7 +76,7 @@ async def export_history_entry_as_m3u(entry, jellyfin_url, jellyfin_api_key):
     lines = ["#EXTM3U"]
 
     for track in entry.get("suggestions", []):
-        title, artist = parse_track_text(track["text"])
+        artist, title = parse_track_text(track["text"])
         album = track.get("album", "Unknown_Album")  # If `album` present in `track`
         if track.get("in_jellyfin"):
             path = await resolve_jellyfin_path(

--- a/tests/test_m3u.py
+++ b/tests/test_m3u.py
@@ -93,7 +93,7 @@ def _setup_roundtrip(monkeypatch, tmp_path, path_template):
     services_stub_local = types.ModuleType("services.jellyfin")
 
     async def dummy_resolve(title, artist, *_a, **_kw):
-        return Path(path_template.format(artist=title, title=artist)).as_posix()
+        return Path(path_template.format(artist=artist, title=title)).as_posix()
 
     async def dummy_search(*_a, **_kw):
         return {"Id": "1"}


### PR DESCRIPTION
## Summary
- correct artist/title order when exporting M3U playlists
- update unit tests for new resolve path order
- mark bug as fixed in BUGS.md

## Testing
- `black .`
- `pylint core api services utils`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ebc1f8fd083329b882ee60e2f79d3