### PR TITLE
Fix uniform Jellyfin popularity bug

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -84,7 +84,7 @@ async def get_cached_playlists(user_id: str | None = None) -> dict:
 【F:core/playlist.py†L241-L255】
 
 ## 9. Uniform Jellyfin play counts lead to zero popularity
-*Open.* When all tracks share the same Jellyfin play count, `min_jf` and `max_jf` are equal. `normalize_popularity` then returns `0` for every track, wiping out the Jellyfin contribution.
+*Fixed.* `normalize_popularity` now returns `100` when all counts are equal and non-zero, preserving the Jellyfin contribution.
 ```
     jellyfin_raw = [t["jellyfin_play_count"] for t in tracks if isinstance(t.get("jellyfin_play_count"), int)]
     min_jf, max_jf = min(jellyfin_raw, default=0), max(jellyfin_raw, default=0)

--- a/core/analysis.py
+++ b/core/analysis.py
@@ -159,8 +159,15 @@ def normalize_popularity(value, min_val, max_val):
         max_val,
     )
     if min_val == max_val:
-        logger.warning("normalize_popularity returning 0 due to min_val == max_val")
-        return 0
+        if min_val == 0:
+            logger.warning(
+                "normalize_popularity returning 0 due to min_val == max_val == 0"
+            )
+            return 0
+        logger.warning(
+            "normalize_popularity returning 100 due to uniform non-zero values"
+        )
+        return 100
     result = round(100 * (value - min_val) / (max_val - min_val), 2)
     logger.debug("normalize_popularity for jellyfin returning %s", result)
     return result

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -25,6 +25,16 @@ def test_add_combined_popularity():
     assert all("combined_popularity" in t for t in result)
 
 
+def test_add_combined_popularity_uniform_counts():
+    """Uniform Jellyfin counts should yield full popularity."""
+    tracks = [
+        {"jellyfin_play_count": 5, "popularity": 100},
+        {"jellyfin_play_count": 5, "popularity": 200},
+    ]
+    result = add_combined_popularity(tracks, w_lfm=0.0, w_jf=1.0)
+    assert all(t["combined_popularity"] == 100 for t in result)
+
+
 def test_summarize_tracks_basic():
     """Summarize a small list of tracks and validate statistics."""
     tracks = [


### PR DESCRIPTION
## Summary
- handle uniform Jellyfin play counts in `normalize_popularity`
- test combined popularity when Jellyfin counts are identical
- mark the bug fixed in `BUGS.md`

## Testing
- `black .`
- `pylint core api services utils`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ec2d73184833285ff3ce18cfac930