### PR TITLE
Fix Windows path naming for playlist import

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -93,12 +93,13 @@ async def get_cached_playlists(user_id: str | None = None) -> dict:
 【F:core/analysis.py†L223-L255】
 
 ## 10. Windows paths not handled when naming imported playlists
-*Open.* `import_m3u_as_history_entry` derives the playlist label using `filepath.split('/')[-1]`. This fails for Windows-style paths with backslashes.
+*Fixed.* `import_m3u_as_history_entry` now derives the label using
+`ntpath.basename(filepath)`, which recognizes both slash types.
 ```
     if imported_tracks:
-        playlist_name = f"Imported - {filepath.split('/')[-1]}"
+        playlist_name = f"Imported - {ntpath.basename(filepath)}"
 ```
-【F:core/m3u.py†L196-L204】
+【F:core/m3u.py†L209-L213】
 
 ## 11. `import_m3u_as_history_entry` treats bool as track metadata
 *Open.* `search_jellyfin_for_track` returns a boolean, but the importer assumes it may return a dict with an `Id` field. As a result `jellyfin_id` is never set and the boolean value is misused.

--- a/core/m3u.py
+++ b/core/m3u.py
@@ -11,6 +11,7 @@ import uuid
 import asyncio
 from datetime import datetime
 from pathlib import Path
+import ntpath
 
 from config import settings
 from services.jellyfin import resolve_jellyfin_path, search_jellyfin_for_track
@@ -206,7 +207,7 @@ async def import_m3u_as_history_entry(filepath: str):
                 artist,
             )
     if imported_tracks:
-        playlist_name = f"Imported - {filepath.split('/')[-1]}"
+        playlist_name = f"Imported - {ntpath.basename(filepath)}"
         save_user_history(user_id, label=playlist_name, suggestions=imported_tracks)
         logger.info(
             "✅ Imported playlist '%s' with %d tracks.",


### PR DESCRIPTION
## Summary
- fix history label derivation when importing M3U playlists by using `ntpath.basename`
- mark Windows path bug as fixed in BUGS.md

## Testing
- `pylint core api services utils`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_687ec4f1b05c8332b1d20d64aad8cb37