### PR TITLE
Fix M3U import metadata bug

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -102,17 +102,19 @@ async def get_cached_playlists(user_id: str | None = None) -> dict:
 【F:core/m3u.py†L209-L213】
 
 ## 11. `import_m3u_as_history_entry` treats bool as track metadata
-*Open.* `search_jellyfin_for_track` returns a boolean, but the importer assumes it may return a dict with an `Id` field. As a result `jellyfin_id` is never set and the boolean value is misused.
+*Fixed.* The importer now uses `fetch_jellyfin_track_metadata` to retrieve a track's metadata and `Id`.
 ```
     tasks = [
-        asyncio.create_task(search_jellyfin_for_track(meta["title"], meta["artist"]))
+        asyncio.create_task(
+            fetch_jellyfin_track_metadata(meta["title"], meta["artist"])
+        )
         for _, meta in metas
     ]
     ...
-    if isinstance(result, dict) and 'Id' in result:
-        enriched['jellyfin_id'] = result['Id']
+    if isinstance(metadata, dict) and "Id" in metadata:
+        enriched["jellyfin_id"] = metadata["Id"]
 ```
-【F:core/m3u.py†L157-L192】
+【F:core/m3u.py†L164-L202】
 
 ## 12. `summarize_tracks` crashes on `None` popularity values
 *Fixed.* `avg_listeners` now filters out ``None`` values and falls back to ``0`` when no valid data is present.

--- a/tests/test_m3u.py
+++ b/tests/test_m3u.py
@@ -17,11 +17,11 @@ initial_services_stub = types.ModuleType("services.jellyfin")
 initial_services_stub.resolve_jellyfin_path = lambda *_a, **_kw: None  # type: ignore[attr-defined]
 
 
-async def _dummy_search(*_a, **_kw):
+async def _dummy_fetch(*_a, **_kw):
     return None
 
 
-initial_services_stub.search_jellyfin_for_track = _dummy_search  # type: ignore[attr-defined]
+initial_services_stub.fetch_jellyfin_track_metadata = _dummy_fetch  # type: ignore[attr-defined]
 sys.modules.setdefault("services.jellyfin", initial_services_stub)
 initial_playlist_stub = types.ModuleType("core.playlist")
 
@@ -95,11 +95,11 @@ def _setup_roundtrip(monkeypatch, tmp_path, path_template):
     async def dummy_resolve(title, artist, *_a, **_kw):
         return Path(path_template.format(artist=artist, title=title)).as_posix()
 
-    async def dummy_search(*_a, **_kw):
+    async def dummy_fetch(*_a, **_kw):
         return {"Id": "1"}
 
     services_stub_local.resolve_jellyfin_path = dummy_resolve
-    services_stub_local.search_jellyfin_for_track = dummy_search
+    services_stub_local.fetch_jellyfin_track_metadata = dummy_fetch
     playlist_stub_local = types.ModuleType("core.playlist")
 
     async def dummy_enrich(track):


### PR DESCRIPTION
## Summary
- fetch full Jellyfin metadata when importing M3U playlists
- adjust tests to stub the new metadata helper
- update bug tracker

## Testing
- `black .`
- `pylint core api services utils`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ec75cdf108332ab0b9d9e595a6bfc