### PR TITLE
Fix YouTube duration filter

### DIFF
--- a/services/metube.py
+++ b/services/metube.py
@@ -63,7 +63,7 @@ async def get_youtube_url_single(search_line: str) -> tuple[str, str | None]:
             e
             for e in entries
             if settings.youtube_min_duration
-            <= e.get("duration", 0)
+            <= (e.get("duration") or 0)
             <= settings.youtube_max_duration
         ]
 


### PR DESCRIPTION
## Summary
- fix duration comparison in `get_youtube_url_single` so missing values are treated as 0

## Testing
- `black .`
- `pylint core api services utils`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_687ed6007384833290eba4785c97fc0b