### PR TITLE
Fix history deletion by unique id

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -310,9 +310,9 @@ async def delete_history(request: Request):
     Delete a playlist entry from the user's history.
     """
     form = await request.form()
-    label = form.get("playlist_name")
+    entry_id = form.get("entry_id")
     history = load_sorted_history(settings.jellyfin_user_id)
-    updated_history = [item for item in history if item.get("label") != label]
+    updated_history = [item for item in history if str(item.get("id")) != str(entry_id)]
     save_whole_user_history(settings.jellyfin_user_id, updated_history)
     return RedirectResponse(url="/history", status_code=303)
 

--- a/templates/history.html
+++ b/templates/history.html
@@ -67,7 +67,7 @@
     </button>
 
     <form action="/history/delete" method="post" style="display:inline;" onsubmit="return confirm('Are you sure you want to delete this playlist?');">
-      <input type="hidden" name="playlist_name" value="{{ entry.label }}">
+      <input type="hidden" name="entry_id" value="{{ entry.id }}">
       <button type="submit" aria-label="Delete playlist {{ entry.label }}" class="text-sm px-2 py-0.5 bg-red-100 text-red-700 rounded hover:bg-red-200">
         🗑️ Delete
       </button>

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -15,3 +15,24 @@ def test_extract_date_from_label_invalid():
     """Return ``datetime.min`` for labels without dates."""
     label = "No Date"
     assert extract_date_from_label(label) == datetime.min
+
+
+def test_delete_history_entry_by_id(monkeypatch, tmp_path):
+    """Deleting by ID should remove only the matching entry."""
+    from core import constants
+    from core.history import save_whole_user_history, load_user_history
+
+    monkeypatch.setattr(constants, "USER_DATA_DIR", tmp_path)
+    user_id = "user"
+
+    entry1 = {"id": "a", "label": "Mix", "suggestions": []}
+    entry2 = {"id": "b", "label": "Mix", "suggestions": []}
+    save_whole_user_history(user_id, [entry1, entry2])
+
+    history = load_user_history(user_id)
+    updated = [item for item in history if item.get("id") != "a"]
+    save_whole_user_history(user_id, updated)
+
+    final = load_user_history(user_id)
+    assert len(final) == 1
+    assert final[0]["id"] == "b"

--- a/tests/test_history_suggestions.py
+++ b/tests/test_history_suggestions.py
@@ -73,6 +73,7 @@ def test_persist_history_and_load(monkeypatch, tmp_path):
     history = load_user_history("user")
     assert history
     assert history[0]["suggestions"] == suggestions
+    assert "id" in history[0]
 
 
 def test_enrich_suggestion_incomplete():


### PR DESCRIPTION
## Summary
- add unique `id` for history entries
- delete history entries using this `id`
- persist missing ids when loading history
- update history template to send id
- test id persistence and deletion logic

## Testing
- `black .`
- `pylint core api services utils`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_687ed92583408332af2988047f1260ad