### PR TITLE
Fix test imports and run tests with PYTHONPATH

### DIFF
--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -2,7 +2,12 @@
 
 from datetime import datetime
 
-from core.history import extract_date_from_label
+from core import constants
+from core.history import (
+    extract_date_from_label,
+    save_whole_user_history,
+    load_user_history,
+)
 
 
 def test_extract_date_from_label_extra_hyphen():
@@ -19,9 +24,6 @@ def test_extract_date_from_label_invalid():
 
 def test_delete_history_entry_by_id(monkeypatch, tmp_path):
     """Deleting by ID should remove only the matching entry."""
-    from core import constants
-    from core.history import save_whole_user_history, load_user_history
-
     monkeypatch.setattr(constants, "USER_DATA_DIR", tmp_path)
     user_id = "user"
 


### PR DESCRIPTION
## Summary
- move imports in `tests/test_history.py` to the top of the file
- keep constants patched the same way

## Testing
- `pylint core api services utils`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ede91a3688332aeb2f7a5fe0b2408