### PR TITLE
Use IDs for history deletion

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -46,7 +46,7 @@ from config import (
 from core.analysis import summarize_tracks, add_combined_popularity
 from core.history import (
     extract_date_from_label,
-    save_whole_user_history,
+    delete_history_entry_by_id,
 )
 from core.m3u import (
     export_history_entry_as_m3u,
@@ -311,9 +311,7 @@ async def delete_history(request: Request):
     """
     form = await request.form()
     entry_id = form.get("entry_id")
-    history = load_sorted_history(settings.jellyfin_user_id)
-    updated_history = [item for item in history if str(item.get("id")) != str(entry_id)]
-    save_whole_user_history(settings.jellyfin_user_id, updated_history)
+    delete_history_entry_by_id(settings.jellyfin_user_id, entry_id)
     return RedirectResponse(url="/history", status_code=303)
 
 

--- a/core/history.py
+++ b/core/history.py
@@ -118,3 +118,25 @@ def save_whole_user_history(user_id: str, history: list[dict]) -> None:
         json.dump(history, f, indent=2)
     logger.debug("History saved to %s", history_file)
     logger.debug("Saved %d history entries", len(history))
+
+
+def delete_history_entry_by_id(user_id: str, entry_id: str) -> bool:
+    """Remove a single history entry matching ``entry_id``.
+
+    Args:
+        user_id: Jellyfin user ID
+        entry_id: The unique identifier of the entry to delete
+
+    Returns:
+        bool: ``True`` if an entry was removed, ``False`` otherwise.
+    """
+
+    history = load_user_history(user_id)
+    before = len(history)
+    updated_history = [h for h in history if str(h.get("id")) != str(entry_id)]
+
+    if len(updated_history) == before:
+        return False
+
+    save_whole_user_history(user_id, updated_history)
+    return True

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -7,6 +7,7 @@ from core.history import (
     extract_date_from_label,
     save_whole_user_history,
     load_user_history,
+    delete_history_entry_by_id,
 )
 
 
@@ -31,9 +32,7 @@ def test_delete_history_entry_by_id(monkeypatch, tmp_path):
     entry2 = {"id": "b", "label": "Mix", "suggestions": []}
     save_whole_user_history(user_id, [entry1, entry2])
 
-    history = load_user_history(user_id)
-    updated = [item for item in history if item.get("id") != "a"]
-    save_whole_user_history(user_id, updated)
+    delete_history_entry_by_id(user_id, "a")
 
     final = load_user_history(user_id)
     assert len(final) == 1


### PR DESCRIPTION
## Summary
- add `delete_history_entry_by_id` helper for history files
- delete history entries by unique ID in the FastAPI route
- adjust unit test to use new helper

## Testing
- `black .`
- `pylint core api services utils`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_687f5a18c6cc83328dd748baa5ccdec8