### PR TITLE
Add usage guide and new unit tests

### DIFF
--- a/Docs/architecture.md
+++ b/Docs/architecture.md
@@ -10,3 +10,13 @@ Playlist Pilot is organized into a few key packages:
 - **`templates/`** and **`static/`** – Jinja2 templates and static assets for the web UI.
 
 Settings are managed via `config.py` and stored in `settings.json`. Caching uses DiskCache in the `cache/` directory. The FastAPI app serves both the HTML interface and JSON endpoints. Tests live in the `tests/` directory.
+
+## Data flow
+
+1. Requests arrive at `api/routes.py` and are dispatched to service and core helpers.
+2. External lookups (Jellyfin, Last.fm, GetSongBPM and OpenAI) are performed asynchronously using `httpx`.
+3. The `core` package normalizes and combines metadata into enriched track objects.
+4. Results are cached via `DiskCache` so repeated operations remain fast.
+5. HTML responses are rendered through Jinja2 templates while JSON endpoints expose the same data for API use.
+
+The project is structured so that `api` depends on `core` which in turn relies on the `services` and `utils` layers. This separation keeps business logic isolated from external integrations and makes testing easier.

--- a/Docs/usage_guide.md
+++ b/Docs/usage_guide.md
@@ -1,0 +1,23 @@
+# Usage Guide
+
+This document provides a quick walkthrough of the typical workflow once Playlist Pilot is installed and configured.
+
+## Generating playlists
+
+1. Open the web interface at [http://localhost:8010](http://localhost:8010).
+2. On the home page enter a mood, genre or a short list of seed tracks.
+3. Click **Suggest** and GPT will return a list of tracks with short explanations.
+4. Review the suggestions, edit any tracks if needed and press **Save** to create the playlist in Jellyfin.
+
+You can also download the results as an `.m3u` file from the history page.
+
+## Viewing history
+
+- The **History** link in the navigation bar lists all past suggestions for the current Jellyfin user.
+- Entries are sorted by date with the newest first. Selecting one shows the full suggestion list and provides buttons to export or delete the entry.
+
+## Managing playlists
+
+Use the **Playlists** page to view existing Jellyfin playlists. From here you can compare two playlists or analyse a playlist's mood distribution.
+
+For more advanced concepts see the other documents in this directory.

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ uvicorn main:app --reload --port 8010
 ```
 
 See [Docs/local_installation.md](Docs/local_installation.md) for a detailed walkthrough.
+For a tour of the main screens and how to generate playlists see
+[Docs/usage_guide.md](Docs/usage_guide.md).
 
 ## Configuration
 

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -6,6 +6,7 @@ from core import constants
 from core.history import (
     extract_date_from_label,
     save_whole_user_history,
+    save_user_history,
     load_user_history,
     delete_history_entry_by_id,
 )
@@ -37,3 +38,17 @@ def test_delete_history_entry_by_id(monkeypatch, tmp_path):
     final = load_user_history(user_id)
     assert len(final) == 1
     assert final[0]["id"] == "b"
+
+
+def test_save_user_history_appends(monkeypatch, tmp_path):
+    """New entries should append to the user's history file."""
+    monkeypatch.setattr(constants, "USER_DATA_DIR", tmp_path)
+    monkeypatch.setattr("core.history.USER_DATA_DIR", tmp_path)
+    user_id = "user"
+
+    save_user_history(user_id, "First - 2023-01-01 00:00", [])
+    save_user_history(user_id, "Second - 2023-01-02 00:00", [])
+
+    history = load_user_history(user_id)
+    assert len(history) == 2
+    assert history[0]["label"].startswith("First")

--- a/tests/test_playlist_helpers.py
+++ b/tests/test_playlist_helpers.py
@@ -1,0 +1,100 @@
+"""Tests for additional helpers in ``core.playlist`` and ``utils.helpers``."""
+
+import ast
+from pathlib import Path
+import types
+import pytest
+
+from core import constants
+from core.history import (
+    save_whole_user_history,
+    load_user_history,
+    extract_date_from_label,
+)
+
+
+def _load_helpers_func(name):
+    """Load a function from ``utils.helpers`` without importing the module."""
+    src = Path("utils/helpers.py").read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    func = next(
+        n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name == name
+    )
+    module = ast.Module(body=[func], type_ignores=[])
+    ns = {
+        "settings": types.SimpleNamespace(jellyfin_user_id="user"),
+        "load_user_history": load_user_history,
+        "extract_date_from_label": extract_date_from_label,
+    }
+    exec(compile(module, filename=f"<helpers.{name}>", mode="exec"), ns)
+    return ns[name]
+
+
+load_sorted_history = _load_helpers_func("load_sorted_history")
+
+
+def _load_func(name):
+    """Load a function from ``core.playlist`` without importing the module."""
+    src = Path("core/playlist.py").read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    func = next(
+        n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name == name
+    )
+    assigns = [
+        n
+        for n in tree.body
+        if isinstance(n, ast.Assign)
+        and any(isinstance(t, ast.Name) and t.id == "GENRE_SYNONYMS" for t in n.targets)
+    ]
+    module = ast.Module(body=assigns + [func], type_ignores=[])
+    ns = {}
+    exec(compile(module, filename=f"<{name}>", mode="exec"), ns)
+    return ns[name]
+
+
+parse_suggestion_line = _load_func("parse_suggestion_line")
+infer_decade = _load_func("infer_decade")
+normalize_genre = _load_func("normalize_genre")
+estimate_tempo = _load_func("estimate_tempo")
+extract_tag_value = _load_func("extract_tag_value")
+
+
+def test_parse_suggestion_line_valid():
+    text, reason = parse_suggestion_line("Song - Artist - Album - 2023 - Good")
+    assert text == "Song - Artist - Album - 2023"
+    assert reason == "Good"
+
+
+def test_parse_suggestion_line_invalid():
+    with pytest.raises(ValueError):
+        parse_suggestion_line("Bad Line")
+
+
+def test_infer_decade_and_normalize_genre():
+    assert infer_decade("1994") == "1990s"
+    assert infer_decade("oops") == "Unknown"
+    assert normalize_genre("Alternative Rock") == "alternative"
+
+
+def test_estimate_tempo_basic():
+    assert estimate_tempo(250, "electronic") == 140
+    assert estimate_tempo(400, "rock") == 120
+    assert estimate_tempo(200, "hip hop") == 90
+    assert estimate_tempo(500, "ambient") == 70
+
+
+def test_extract_tag_value():
+    tags = ["tempo:120", "mood:happy"]
+    assert extract_tag_value(tags, "tempo") == "120"
+    assert extract_tag_value(tags, "missing") is None
+
+
+def test_load_sorted_history(monkeypatch, tmp_path):
+    monkeypatch.setattr(constants, "USER_DATA_DIR", tmp_path)
+    entries = [
+        {"id": "1", "label": "Mix - 2023-01-01 10:00", "suggestions": []},
+        {"id": "2", "label": "Mix - 2023-02-01 10:00", "suggestions": []},
+    ]
+    save_whole_user_history("user", entries)
+    sorted_hist = load_sorted_history("user")
+    assert sorted_hist[0]["id"] == "2"

--- a/tests/test_text_utils.py
+++ b/tests/test_text_utils.py
@@ -17,3 +17,12 @@ def test_strip_markdown_basic():
     assert "bold" in cleaned
     assert "italic" in cleaned
     assert "link" in cleaned
+
+
+def test_clean_and_build_query():
+    """Verify text normalization and search query extraction."""
+    assert tu.clean(" Hello!!! ") == "hello"
+    assert tu.clean("MiXeD Case") == "mixed case"
+
+    assert tu.build_search_query("Song - Artist - Extra") == "Song Artist"
+    assert tu.build_search_query("Solo") == "Solo"


### PR DESCRIPTION
## Summary
- document common workflow in new usage guide and expand architecture notes
- link usage guide from README
- add unit tests for helpers in `core.playlist`, `utils.helpers` and history module
- cover additional text utilities

## Testing
- `black .`
- `pylint core api services utils`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f5bdf86748332bd884ca249fe4bb6