### PR TITLE
Fix delete_history form type handling

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -310,7 +310,8 @@ async def delete_history(request: Request):
     Delete a playlist entry from the user's history.
     """
     form = await request.form()
-    entry_id = form.get("entry_id")
+    raw_id = form.get("entry_id")
+    entry_id = raw_id if isinstance(raw_id, str) else ""
     delete_history_entry_by_id(settings.jellyfin_user_id, entry_id)
     return RedirectResponse(url="/history", status_code=303)
 


### PR DESCRIPTION
## Summary
- handle non-str form values when deleting history entries
- cast the entry id to string before deleting to satisfy static checks

## Testing
- `black .`
- `pylint core api services utils`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_687f5fe9ad288332bb8588a768918111