### PR TITLE
Fix pylint exec warnings in tests

### DIFF
--- a/tests/test_playlist_helpers.py
+++ b/tests/test_playlist_helpers.py
@@ -1,5 +1,7 @@
 """Tests for additional helpers in ``core.playlist`` and ``utils.helpers``."""
 
+# pylint: disable=exec-used
+
 import ast
 from pathlib import Path
 import types


### PR DESCRIPTION
## Summary
- silence pylint's `exec-used` warning in `test_playlist_helpers`

## Testing
- `black .`
- `pylint core api services utils`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687f622aa6b88332a5e53c89e02e0b4f