### PR TITLE
Improve configuration UI

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -332,8 +332,10 @@ async def get_settings(request: Request):
     try:
         settings.validate_settings()
         validation_message = None
+        validation_error = False
     except ValueError as ve:
         validation_message = str(ve)
+        validation_error = True
     users = await fetch_jellyfin_users()
     models = await fetch_openai_models(settings.openai_api_key)
 
@@ -344,6 +346,7 @@ async def get_settings(request: Request):
             "settings": settings.dict(),
             "models": models,
             "validation_message": validation_message,
+            "validation_error": validation_error,
             "jellyfin_users": users,
         },
     )
@@ -386,8 +389,10 @@ async def update_settings(
     try:
         settings.validate_settings()
         validation_message = "Settings saved successfully."
+        validation_error = False
     except ValueError as ve:
         validation_message = str(ve)
+        validation_error = True
 
     users = await fetch_jellyfin_users()
     return templates.TemplateResponse(
@@ -396,6 +401,7 @@ async def update_settings(
             "request": request,
             "settings": settings.dict(),
             "validation_message": validation_message,
+            "validation_error": validation_error,
             "models": models,
             "jellyfin_users": users,
         },

--- a/templates/history.html
+++ b/templates/history.html
@@ -2,6 +2,7 @@
 {% block content %}
 
 <h2 class="text-3xl font-extrabold mb-4 text-blue-800 dark:text-blue-300">🎵 Playlist History</h2>
+<p class="text-sm text-gray-600 dark:text-gray-300 mb-4">View, export, or remove your previously generated playlists.</p>
 
 {% if deleted and deleted > 0 %}
   <div class="mb-4 p-2 rounded bg-green-100 text-green-800">
@@ -50,6 +51,7 @@
 <div class="flex justify-between items-center mb-2">
   <div class="flex items-center gap-2">
     <div class="text-2xl font-semibold text-gray-800 dark:text-gray-100 truncate">🎼 {{ entry.label }}
+      <span class="ml-1 text-sm text-gray-500">({{ entry.suggestions | length }})</span>
       {% if 'Imported' in entry.label %}
         <span class="ml-2 inline-block bg-yellow-100 text-yellow-800 text-xs font-semibold rounded px-2">Imported</span>
       {% endif %}
@@ -121,7 +123,9 @@
       {% endfor %}
     </div>
 {% else %}
-  <p class="text-gray-500">No saved history yet. Try generating a playlist first.</p>
+  <div class="p-4 bg-yellow-100 text-yellow-800 rounded">
+    ⚠️ No saved history yet. Generate a playlist to see it here.
+  </div>
 {% endif %}
 
 <div id="toast-container" class="fixed top-4 right-4 space-y-2 z-50"></div>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -10,10 +10,20 @@
     </button>
   </h1>
   <p class="text-sm text-gray-600 dark:text-gray-300 mb-4">Manage how Playlist Pilot connects to your services.</p>
+  <p class="text-xs text-gray-500 mb-4">Fields marked with <span class="text-red-600">*</span> are required.</p>
 
   {% if validation_message %}
-    <div class="bg-yellow-100 border-l-4 border-yellow-400 p-4 mb-4 text-yellow-800">
-      ⚠️ <strong>Configuration Warning:</strong> {{ validation_message }}
+    <div class="p-4 mb-4 border-l-4 rounded
+                {% if validation_error %}
+                  bg-yellow-100 border-yellow-400 text-yellow-800
+                {% else %}
+                  bg-green-100 border-green-400 text-green-800
+                {% endif %}">
+      {% if validation_error %}
+        ⚠️ <strong>Configuration Warning:</strong> {{ validation_message }}
+      {% else %}
+        ✅ {{ validation_message }}
+      {% endif %}
     </div>
   {% endif %}
   {% if jellyfin_users|length == 0 %}


### PR DESCRIPTION
## Summary
- add validation_error flag for settings handlers
- show clearer success/warning messages in settings
- enhance history page with instructions and track counts

## Testing
- `black .`
- `pylint core api services utils`
- `PYTHONPATH=$PWD pytest`

------
https://chatgpt.com/codex/tasks/task_e_687f63b652588332a3fe8791bf3c5012