### PR TITLE
Expose log excerpts in templates

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -81,6 +81,7 @@ from utils.helpers import (
     get_cached_playlists,
     load_sorted_history,
     parse_suggest_request,
+    get_log_excerpt,
 )
 from api.forms import SettingsForm
 
@@ -298,9 +299,16 @@ async def history_page(
     elif sort == "za":
         history.sort(key=lambda e: e["label"].lower(), reverse=True)
 
+    log_excerpt = get_log_excerpt()
     return templates.TemplateResponse(
         "history.html",
-        {"request": request, "history": history, "sort": sort, "deleted": deleted},
+        {
+            "request": request,
+            "history": history,
+            "sort": sort,
+            "deleted": deleted,
+            "log_excerpt": log_excerpt,
+        },
     )
 
 
@@ -338,6 +346,7 @@ async def get_settings(request: Request):
         validation_error = True
     users = await fetch_jellyfin_users()
     models = await fetch_openai_models(settings.openai_api_key)
+    log_excerpt = get_log_excerpt()
 
     return templates.TemplateResponse(
         "settings.html",
@@ -348,6 +357,7 @@ async def get_settings(request: Request):
             "validation_message": validation_message,
             "validation_error": validation_error,
             "jellyfin_users": users,
+            "log_excerpt": log_excerpt,
         },
     )
 
@@ -395,6 +405,7 @@ async def update_settings(
         validation_error = True
 
     users = await fetch_jellyfin_users()
+    log_excerpt = get_log_excerpt()
     return templates.TemplateResponse(
         "settings.html",
         {
@@ -404,6 +415,7 @@ async def update_settings(
             "validation_error": validation_error,
             "models": models,
             "jellyfin_users": users,
+            "log_excerpt": log_excerpt,
         },
     )
 

--- a/templates/history.html
+++ b/templates/history.html
@@ -5,7 +5,7 @@
 <p class="text-sm text-gray-600 dark:text-gray-300 mb-4">View, export, or remove your previously generated playlists.</p>
 
 {% if deleted and deleted > 0 %}
-  <div class="mb-4 p-2 rounded bg-green-100 text-green-800">
+  <div class="mb-6 p-4 rounded bg-green-100 text-green-800 border-l-4 border-green-400 shadow text-lg font-semibold">
     ✅ {{ deleted }} playlist{{ 's' if deleted > 1 else '' }} deleted successfully.
   </div>
 {% endif %}
@@ -129,6 +129,11 @@
 {% endif %}
 
 <div id="toast-container" class="fixed top-4 right-4 space-y-2 z-50"></div>
+
+{% if log_excerpt %}
+  <h2 class="text-xl font-semibold mt-8">Recent Logs</h2>
+  <pre class="bg-gray-800 text-green-300 p-4 rounded overflow-auto text-xs max-h-60 whitespace-pre-wrap">{{ log_excerpt | join('\n') }}</pre>
+{% endif %}
 
 <script>
 document.addEventListener('DOMContentLoaded', () => {

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -13,7 +13,7 @@
   <p class="text-xs text-gray-500 mb-4">Fields marked with <span class="text-red-600">*</span> are required.</p>
 
   {% if validation_message %}
-    <div class="p-4 mb-4 border-l-4 rounded
+    <div class="p-4 mb-6 border-l-4 rounded shadow text-lg font-semibold
                 {% if validation_error %}
                   bg-yellow-100 border-yellow-400 text-yellow-800
                 {% else %}
@@ -220,6 +220,11 @@
       <a href="/" class="text-sm text-blue-600 hover:underline">Cancel</a>
     </div>
   </form>
+
+  {% if log_excerpt %}
+    <h2 class="text-xl font-semibold mt-8">Recent Logs</h2>
+    <pre class="bg-gray-800 text-green-300 p-4 rounded overflow-auto text-xs max-h-60 whitespace-pre-wrap">{{ log_excerpt | join('\n') }}</pre>
+  {% endif %}
 
   <script>
     window.updateStatus = function(id, result, message) {

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -9,7 +9,9 @@ from fastapi import Request
 from config import settings
 from core.history import load_user_history, extract_date_from_label
 from core.playlist import fetch_audio_playlists
+from core.constants import LOG_FILE
 from utils.cache_manager import playlist_cache, CACHE_TTLS
+
 
 logger = logging.getLogger("playlist-pilot")
 
@@ -53,3 +55,17 @@ async def parse_suggest_request(request: Request) -> tuple[list[dict], str, str]
         tracks = []
 
     return tracks, playlist_name, text_summary
+
+
+def get_log_excerpt(lines: int = 20) -> list[str]:
+    """Return the last ``lines`` lines from the application log file."""
+    log_path = LOG_FILE
+    if not log_path.exists():
+        return []
+    try:
+        with open(log_path, "r", encoding="utf-8") as file:
+            data = file.readlines()[-lines:]
+        return [ln.rstrip() for ln in data]
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        logger.error("Failed to read log file: %s", exc)
+        return [f"Error reading log file: {exc}"]


### PR DESCRIPTION
## Summary
- surface recent log messages on Settings and History pages
- highlight validation and status messages with larger styling
- utility to tail log file

## Testing
- `black .`
- `pylint core api services utils`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_687f6a971b908332b6d0bcb235db13a7