### PR TITLE
Add docs and edge case tests

### DIFF
--- a/Docs/advanced_usage.md
+++ b/Docs/advanced_usage.md
@@ -1,0 +1,10 @@
+# Advanced Usage
+
+Once you are comfortable generating playlists there are several ways to customise Playlist Pilot.
+
+- **Weights** – The influence of lyrics, BPM and Last.fm tags on mood detection can be tweaked in the settings page.
+- **Cache control** – Clear individual caches from the settings page or via the CLI to force fresh lookups.
+- **Library scans** – Increase `library_scan_limit` if your Jellyfin library is large and you want more tracks analysed per request.
+- **Models** – Provide your own OpenAI model name if you have access to a custom one.
+
+These options allow power users to fine‑tune the suggestion engine and metadata enrichment process.

--- a/Docs/configuration.md
+++ b/Docs/configuration.md
@@ -1,0 +1,11 @@
+# Configuration
+
+Playlist Pilot reads its settings from `settings.json` and environment variables. Use `env.example` as a reference and copy it to `.env` with your own values.
+
+Key options include:
+
+- `jellyfin_url`, `jellyfin_api_key`, and `jellyfin_user_id` for connecting to your Jellyfin server.
+- `openai_api_key` and `lastfm_api_key` for metadata enrichment and suggestions.
+- Cache TTLs and feature weights found in `config.py` can be adjusted to tune performance.
+
+After editing the configuration restart the application for changes to take effect.

--- a/Docs/playlist_management.md
+++ b/Docs/playlist_management.md
@@ -1,0 +1,9 @@
+# Playlist Management
+
+The History page keeps a record of every playlist suggestion that has been generated. From here you can:
+
+- Download the suggestion as an `.m3u` file.
+- Delete old entries you no longer need.
+- Compare two saved suggestions or Jellyfin playlists via the **Compare** page.
+
+You can also import existing M3U files which will be stored in your history for later analysis and export to Jellyfin.

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -4,6 +4,9 @@ from core.analysis import (
     combined_popularity_score,
     add_combined_popularity,
     summarize_tracks,
+    percent_distribution,
+    normalize_popularity,
+    normalized_entropy,
 )
 
 
@@ -68,3 +71,21 @@ def test_summarize_tracks_empty_list():
     summary = summarize_tracks([])
     assert summary["avg_listeners"] == 0
     assert summary["avg_popularity"] == 0
+
+
+def test_percent_distribution_rounding():
+    """Percentages should sum to 100 even with fractional parts."""
+    result = percent_distribution(["a", "a", "b"])
+    assert result == {"a": "67%", "b": "33%"}
+    assert sum(int(v.rstrip("%")) for v in result.values()) == 100
+
+
+def test_normalize_popularity_edge_cases():
+    """Handle uniform value ranges correctly."""
+    assert normalize_popularity(0, 0, 0) == 0
+    assert normalize_popularity(5, 5, 5) == 100
+
+
+def test_normalized_entropy_identical():
+    """Entropy of identical values should be zero."""
+    assert normalized_entropy(["rock", "rock", "rock"]) == 0.0

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -5,6 +5,8 @@
 import ast
 from pathlib import Path
 import asyncio
+import pytest
+from fastapi import HTTPException
 
 
 def _extract_health_check():
@@ -30,3 +32,81 @@ def test_health_check():
     health_check = _extract_health_check()
     result = asyncio.get_event_loop().run_until_complete(health_check())
     assert result == {"status": "ok"}
+
+
+def _extract_export_m3u():
+    """Return the ``export_m3u`` coroutine without side effects."""
+    src = Path("api/routes.py").read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    func = next(
+        n
+        for n in tree.body
+        if isinstance(n, ast.AsyncFunctionDef) and n.name == "export_m3u"
+    )
+    func.decorator_list = []
+    module = ast.Module(body=[func], type_ignores=[])
+    ns = {
+        "HTTPException": HTTPException,
+        "BackgroundTask": object,
+        "FileResponse": object,
+        "resolve_jellyfin_path": lambda *a, **k: None,
+        "settings": object,
+        "uuid": __import__("uuid"),
+        "tempfile": __import__("tempfile"),
+        "Path": Path,
+        "Request": object,
+    }
+    exec(compile(module, filename="<export_m3u>", mode="exec"), ns)
+    return ns["export_m3u"]
+
+
+def _extract_import_m3u_file():
+    """Return ``import_m3u_file`` coroutine without importing ``api.routes``."""
+    src = Path("api/routes.py").read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    func = next(
+        n
+        for n in tree.body
+        if isinstance(n, ast.AsyncFunctionDef) and n.name == "import_m3u_file"
+    )
+    func.decorator_list = []
+    func.args.defaults = []
+    func.args.args[0].annotation = None
+    func.returns = None
+    module = ast.Module(body=[func], type_ignores=[])
+    ns = {
+        "HTTPException": HTTPException,
+        "import_m3u_as_history_entry": lambda _: None,
+        "cleanup_temp_file": lambda _: None,
+        "tempfile": __import__("tempfile"),
+        "shutil": __import__("shutil"),
+        "Path": Path,
+        "RedirectResponse": type("Resp", (), {}),
+    }
+    exec(compile(module, filename="<import_m3u_file>", mode="exec"), ns)
+    return ns["import_m3u_file"]
+
+
+def test_export_m3u_no_tracks():
+    """``export_m3u`` should reject empty track lists."""
+    export_m3u = _extract_export_m3u()
+
+    class DummyReq:
+        async def json(self):
+            return {"name": "x", "tracks": []}
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.get_event_loop().run_until_complete(export_m3u(DummyReq()))
+    assert exc.value.status_code == 400
+
+
+def test_import_m3u_file_invalid_extension(tmp_path):
+    """Invalid file extensions should result in ``HTTPException``."""
+    from starlette.datastructures import UploadFile
+
+    dummy = UploadFile(tmp_path / "test.txt", filename="test.txt")
+    import_m3u = _extract_import_m3u_file()
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.get_event_loop().run_until_complete(import_m3u(dummy))
+    assert exc.value.status_code == 400


### PR DESCRIPTION
## Summary
- document configuration, advanced usage and playlist management
- extend analysis tests for distribution and normalization edge cases
- add route tests for empty export and invalid M3U upload

## Testing
- `black .`
- `pylint core api services utils`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f6d0a595083328e6d660251edcd71