### PR TITLE
Fix M3U export title/artist parsing

### DIFF
--- a/core/m3u.py
+++ b/core/m3u.py
@@ -38,9 +38,11 @@ INVALID_CHARS_RE = re.compile(r"[\\/:*?\"<>|]")
 
 
 def _parse_title_artist(text: str) -> tuple[str, str]:
-    """Parse a saved suggestion line into title and artist."""
+    """Return the title and artist from a suggestion line."""
     parts = [p.strip() for p in text.split(" - ")]
-    return (parts[1], parts[0]) if len(parts) >= 2 else ("", "")
+    if len(parts) >= 2:
+        return parts[0], parts[1]
+    return "", ""
 
 
 def _sanitize_component(value: str, fallback: str) -> str:

--- a/tests/test_m3u.py
+++ b/tests/test_m3u.py
@@ -36,6 +36,7 @@ from core.m3u import (
     parse_track_text,
     infer_track_metadata_from_path,
     generate_proposed_path,
+    _parse_title_artist,
 )  # pylint: disable=wrong-import-position
 
 
@@ -58,6 +59,13 @@ def test_parse_track_text_extra_parts():
     artist, title = parse_track_text("Metallica - One - Live")
     assert artist == "Metallica"
     assert title == "One"
+
+
+def test_parse_title_artist_full_line():
+    """Extract title and artist from a suggestion line."""
+    title, artist = _parse_title_artist("Song Name - Artist Name - Album - 2024")
+    assert title == "Song Name"
+    assert artist == "Artist Name"
 
 
 def test_infer_metadata_artist_title():
@@ -127,7 +135,7 @@ def _roundtrip(monkeypatch, tmp_path, path_template):
     m3u, history = _setup_roundtrip(monkeypatch, tmp_path, path_template)
     entry = {
         "suggestions": [
-            {"text": "Artist - Title", "in_jellyfin": True, "album": "Album"}
+            {"text": "Title - Artist", "in_jellyfin": True, "album": "Album"}
         ]
     }
     loop = asyncio.get_event_loop()


### PR DESCRIPTION
## Summary
- correct `_parse_title_artist` ordering so title isn't swapped with artist
- update round-trip playlist test to use `Title - Artist` format
- add new unit test for `_parse_title_artist`

## Testing
- `pylint core api services utils`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f77f3f6148332aeb02b734dd90b3f