### PR TITLE
Fix settings validation bug

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -4,16 +4,6 @@ This file documents outstanding bugs discovered during a code audit.
 Fixed issues have been moved to [FIXED_BUGS.md](FIXED_BUGS.md).
 
 
-## 40. Invalid settings persisted before validation
-`update_settings` writes the new configuration to disk prior to calling `validate_settings`, so bad input still overwrites ``settings.json``.
-```
-save_settings(settings)
-try:
-    settings.validate_settings()
-    validation_message = "Settings saved successfully."
-```
-【F:api/routes.py†L368-L402】
-
 ## 26. Temporary M3U files written with unsupported newline argument
 `export_history_entry_as_m3u` calls `Path.write_text()` using a `newline` parameter, which does not exist and raises `TypeError` at runtime.
 ```

--- a/FIXED_BUGS.md
+++ b/FIXED_BUGS.md
@@ -244,3 +244,19 @@ if not logger.handlers:
 ```
 【F:main.py†L36-L41】
 
+## 22. Invalid settings persisted before validation
+*Fixed.* `update_settings` now validates the form input before saving to `settings.json` so invalid data is not persisted.
+
+Code:
+```
+    try:
+        settings.validate_settings()
+        save_settings(settings)
+        validation_message = "Settings saved successfully."
+        validation_error = False
+    except ValueError as ve:
+        validation_message = str(ve)
+        validation_error = True
+```
+【F:api/routes.py†L392-L407】
+

--- a/api/routes.py
+++ b/api/routes.py
@@ -394,10 +394,9 @@ async def update_settings(
     settings.bpm_weight = form_data.bpm_weight
     settings.tags_weight = form_data.tags_weight
 
-    save_settings(settings)
-
     try:
         settings.validate_settings()
+        save_settings(settings)
         validation_message = "Settings saved successfully."
         validation_error = False
     except ValueError as ve:


### PR DESCRIPTION
## Summary
- validate settings before saving to JSON
- move 'Invalid settings persisted before validation' bug from BUGS to FIXED_BUGS

## Testing
- `black .`
- `pylint core api services utils`
- `PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_e_687fef3084fc83329c2715a5abdb6d13