### PR TITLE
Fix newline argument in M3U export

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -4,14 +4,6 @@ This file documents outstanding bugs discovered during a code audit.
 Fixed issues have been moved to [FIXED_BUGS.md](FIXED_BUGS.md).
 
 
-## 26. Temporary M3U files written with unsupported newline argument
-`export_history_entry_as_m3u` calls `Path.write_text()` using a `newline` parameter, which does not exist and raises `TypeError` at runtime.
-```
-    m3u_path = Path(tempfile.gettempdir()) / f"suggest_{uuid.uuid4().hex}.m3u"
-    m3u_path.write_text("\n".join(lines), encoding="utf-8", newline="\n")
-```
-【F:core/m3u.py†L124-L125】
-
 ## 44. M3U import aborts on a single metadata failure
 `import_m3u_as_history_entry` awaits ``asyncio.gather`` without ``return_exceptions`` so one failing request stops the entire import.
 ```

--- a/FIXED_BUGS.md
+++ b/FIXED_BUGS.md
@@ -260,3 +260,13 @@ Code:
 ```
 【F:api/routes.py†L392-L407】
 
+## 23. Temporary M3U files written with unsupported newline argument
+*Fixed.* `export_history_entry_as_m3u` no longer passes an unsupported `newline` parameter to `Path.write_text`.
+
+Code:
+```
+    m3u_path = Path(tempfile.gettempdir()) / f"suggest_{uuid.uuid4().hex}.m3u"
+    m3u_path.write_text("\n".join(lines), encoding="utf-8")
+```
+【F:core/m3u.py†L124-L125】
+

--- a/core/m3u.py
+++ b/core/m3u.py
@@ -122,7 +122,7 @@ async def export_history_entry_as_m3u(entry, jellyfin_url, jellyfin_api_key):
             lines.append(f"# Suggested (not in library): {proposed_path}")
 
     m3u_path = Path(tempfile.gettempdir()) / f"suggest_{uuid.uuid4().hex}.m3u"
-    m3u_path.write_text("\n".join(lines), encoding="utf-8", newline="\n")
+    m3u_path.write_text("\n".join(lines), encoding="utf-8")
 
     logger.info(
         "Wrote hybrid M3U playlist with %d entries: %s",


### PR DESCRIPTION
## Summary
- remove unsupported `newline` parameter from M3U export
- document fix in `FIXED_BUGS.md`
- remove bug entry from `BUGS.md`

## Testing
- `black .`
- `pylint core api services utils`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68800059451c8332b0b3a2cefc2612fe