### PR TITLE
Fix normalize_popularity_log bounds bug

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -4,15 +4,6 @@ This file documents outstanding bugs discovered during a code audit.
 Fixed issues have been moved to [FIXED_BUGS.md](FIXED_BUGS.md).
 
 
-## 42. ``normalize_popularity_log`` crashes with zero bounds
-The function calls ``math.log10`` on ``min_val`` and ``max_val`` without checking they are positive.
-```
-log_min = math.log10(min_val)
-log_max = math.log10(max_val)
-log_val = math.log10(value)
-```
-【F:core/analysis.py†L248-L250】
-
 ## 37. Logging fails when combined popularity is ``None``
 `enrich_and_score_suggestions` formats the score with ``%.1f`` even when `combined_popularity` is ``None`` which raises ``TypeError``.
 ```

--- a/FIXED_BUGS.md
+++ b/FIXED_BUGS.md
@@ -289,3 +289,20 @@ Code:
 ```
 【F:core/m3u.py†L196-L215】
 
+## 42. ``normalize_popularity_log`` crashes with zero bounds
+*Fixed.* The helper now verifies both bounds are positive and returns ``0`` when they are not.
+
+Code snippet:
+```python
+    if min_val <= 0 or max_val <= 0:
+        logger.warning(
+            "normalize_popularity_log returning 0 due to non-positive bounds"
+        )
+        return 0
+    if min_val == max_val:
+        logger.warning(
+            "normalize_popularity_log returning %s due to uniform bounds", 100
+        )
+        return 100
+```
+【F:core/analysis.py†L239-L255】

--- a/core/analysis.py
+++ b/core/analysis.py
@@ -245,6 +245,16 @@ def normalize_popularity_log(value, min_val, max_val):
             "normalize_popularity_log for lastfm returning 0 (value is None or <= 0)"
         )
         return 0
+    if min_val <= 0 or max_val <= 0:
+        logger.warning(
+            "normalize_popularity_log returning 0 due to non-positive bounds"
+        )
+        return 0
+    if min_val == max_val:
+        logger.warning(
+            "normalize_popularity_log returning %s due to uniform bounds", 100
+        )
+        return 100
     log_min = math.log10(min_val)
     log_max = math.log10(max_val)
     log_val = math.log10(value)

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -6,6 +6,7 @@ from core.analysis import (
     summarize_tracks,
     percent_distribution,
     normalize_popularity,
+    normalize_popularity_log,
     normalized_entropy,
 )
 
@@ -89,3 +90,10 @@ def test_normalize_popularity_edge_cases():
 def test_normalized_entropy_identical():
     """Entropy of identical values should be zero."""
     assert normalized_entropy(["rock", "rock", "rock"]) == 0.0
+
+
+def test_normalize_popularity_log_bounds():
+    """Edge cases for ``normalize_popularity_log`` should not error."""
+    assert normalize_popularity_log(10, 0, 0) == 0
+    assert normalize_popularity_log(10, -5, 5) == 0
+    assert normalize_popularity_log(10, 5, 5) == 100


### PR DESCRIPTION
## Summary
- avoid math domain error when min/max are zero or negative
- test normalize_popularity_log edge cases
- move bug 42 to FIXED_BUGS

## Testing
- `pylint core api services utils`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68800d1e8c3483329f690cb391d4ef5b