### PR TITLE
Fix logging with None combined popularity

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -4,21 +4,6 @@ This file documents outstanding bugs discovered during a code audit.
 Fixed issues have been moved to [FIXED_BUGS.md](FIXED_BUGS.md).
 
 
-## 37. Logging fails when combined popularity is ``None``
-`enrich_and_score_suggestions` formats the score with ``%.1f`` even when `combined_popularity` is ``None`` which raises ``TypeError``.
-```
-for track in suggestions:
-    logger.info(
-        "%s - %s | Combined: %.1f | Last.fm: %s, Jellyfin: %s",
-        track["title"],
-        track["artist"],
-        track["combined_popularity"],
-        raw_lfm,
-        raw_jf,
-    )
-```
-【F:core/playlist.py†L686-L697】
-
 ## 36. OpenAI clients ignore updated API keys
 `sync_openai_client` and `async_openai_client` are created at import time using the initial `openai_api_key`. Updating the key through `/settings` leaves these clients unchanged.
 ```

--- a/FIXED_BUGS.md
+++ b/FIXED_BUGS.md
@@ -306,3 +306,20 @@ Code snippet:
         return 100
 ```
 【F:core/analysis.py†L239-L255】
+
+## 37. Logging fails when combined popularity is ``None``
+*Fixed.* The logger now formats ``combined_popularity`` with ``%s`` so ``None`` values no longer raise ``TypeError``.
+
+Code snippet:
+```python
+        combined = track.get("combined_popularity")
+        logger.info(
+            "%s - %s | Combined: %s | Last.fm: %s, Jellyfin: %s",
+            track["title"],
+            track["artist"],
+            f"{combined:.1f}" if isinstance(combined, (int, float)) else combined,
+            raw_lfm,
+            raw_jf,
+        )
+```
+【F:core/playlist.py†L688-L698】

--- a/core/playlist.py
+++ b/core/playlist.py
@@ -687,11 +687,12 @@ async def enrich_and_score_suggestions(suggestions_raw: list[dict]) -> list[dict
     for track in suggestions:
         raw_lfm = track.get("popularity")
         raw_jf = track.get("jellyfin_play_count")
+        combined = track.get("combined_popularity")
         logger.info(
-            "%s - %s | Combined: %.1f | Last.fm: %s, Jellyfin: %s",
+            "%s - %s | Combined: %s | Last.fm: %s, Jellyfin: %s",
             track["title"],
             track["artist"],
-            track["combined_popularity"],
+            f"{combined:.1f}" if isinstance(combined, (int, float)) else combined,
             raw_lfm,
             raw_jf,
         )


### PR DESCRIPTION
## Summary
- handle None values when logging combined popularity
- document fixed bug about None popularity values

## Testing
- `pylint core api services utils`
- `pytest` *(fails: ModuleNotFoundError: No module named 'core')*

------
https://chatgpt.com/codex/tasks/task_e_688159c1d6908332a61f91ac82b49e26