### PR TITLE
Fix caching for Jellyfin search failures

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -4,18 +4,6 @@ This file documents outstanding bugs discovered during a code audit.
 Fixed issues have been moved to [FIXED_BUGS.md](FIXED_BUGS.md).
 
 
-## 23. Network failures cached as missing Jellyfin tracks
-If `search_jellyfin_for_track` encounters an HTTP error, it stores `False`
-in the cache, permanently marking the track as absent.
-```
-except Exception as exc:  # pylint: disable=broad-exception-caught
-    record_failure("jellyfin")
-    logger.warning("Jellyfin search failed for %s - %s: %s", title, artist, exc)
-    jellyfin_track_cache.set(key, False, expire=CACHE_TTLS["jellyfin_tracks"])
-    return False
-```
-【F:services/jellyfin.py†L91-L95】
-
 ## 30. Last.fm errors cached as track absence
 `get_lastfm_track_info` caches `False` when any exception occurs, so network issues mark the track as missing until the cache expires.
 ```

--- a/FIXED_BUGS.md
+++ b/FIXED_BUGS.md
@@ -334,3 +334,15 @@ def get_async_openai_client() -> AsyncOpenAI:
     return AsyncOpenAI(api_key=settings.openai_api_key)
 ```
 【F:services/gpt.py†L22-L29】
+
+## 23. Network failures cached as missing Jellyfin tracks
+*Fixed.* The search function no longer caches failures, preventing transient
+errors from marking tracks as permanently absent.
+```python
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        record_failure("jellyfin")
+        logger.warning("Jellyfin search failed for %s - %s: %s", title, artist, exc)
+        # Avoid caching failures so transient issues don't mark the track as missing
+        return False
+```
+【F:services/jellyfin.py†L91-L95】

--- a/services/jellyfin.py
+++ b/services/jellyfin.py
@@ -91,7 +91,7 @@ async def search_jellyfin_for_track(title: str, artist: str) -> bool:
     except Exception as exc:  # pylint: disable=broad-exception-caught
         record_failure("jellyfin")
         logger.warning("Jellyfin search failed for %s - %s: %s", title, artist, exc)
-        jellyfin_track_cache.set(key, False, expire=CACHE_TTLS["jellyfin_tracks"])
+        # Avoid caching failures so transient issues don't mark the track as missing
         return False
 
 


### PR DESCRIPTION
## Summary
- avoid caching Jellyfin search failures so network errors don't mark tracks as missing
- document the fix in `FIXED_BUGS.md`
- remove the corresponding entry from `BUGS.md`

## Testing
- `black .`
- `pylint core api services utils`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_688166719f588332860ad1af8c353d35