### PR TITLE
Fix lastfm caching bug

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -4,16 +4,6 @@ This file documents outstanding bugs discovered during a code audit.
 Fixed issues have been moved to [FIXED_BUGS.md](FIXED_BUGS.md).
 
 
-## 30. Last.fm errors cached as track absence
-`get_lastfm_track_info` caches `False` when any exception occurs, so network issues mark the track as missing until the cache expires.
-```
-    except Exception as exc:  # pylint: disable=broad-exception-caught
-        record_failure("lastfm")
-        logger.warning("Last.fm lookup failed for %s - %s: %s", title, artist, exc)
-        lastfm_cache.set(key, False, expire=CACHE_TTLS["lastfm"])
-        return None
-```
-【F:services/lastfm.py†L108-L112】
 
 ## 27. Playlist fetch failures cached permanently
 `get_cached_playlists` stores the error response in the cache, so a transient fetch failure leaves the error cached until the TTL expires.

--- a/FIXED_BUGS.md
+++ b/FIXED_BUGS.md
@@ -346,3 +346,14 @@ errors from marking tracks as permanently absent.
         return False
 ```
 【F:services/jellyfin.py†L91-L95】
+
+## 30. Last.fm errors cached as track absence
+*Fixed.* `get_lastfm_track_info` now returns ``None`` without caching when a request fails.
+```python
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        record_failure("lastfm")
+        logger.warning("Last.fm lookup failed for %s - %s: %s", title, artist, exc)
+        # Avoid caching failures so transient issues don't mark the track as missing
+        return None
+```
+【F:services/lastfm.py†L108-L112】

--- a/services/lastfm.py
+++ b/services/lastfm.py
@@ -108,7 +108,7 @@ async def get_lastfm_track_info(title: str, artist: str) -> dict | None:
     except Exception as exc:  # pylint: disable=broad-exception-caught
         record_failure("lastfm")
         logger.warning("Last.fm lookup failed for %s - %s: %s", title, artist, exc)
-        lastfm_cache.set(key, False, expire=CACHE_TTLS["lastfm"])
+        # Avoid caching failures so transient issues don't mark the track as missing
         return None
 
 


### PR DESCRIPTION
## Summary
- avoid caching failed Last.fm lookups
- move bug 30 to FIXED_BUGS

## Testing
- `black .`
- `pylint core api services utils`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688167f4feb483329de6c663984228e5