### PR TITLE
Fix playlist cache error

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -5,16 +5,6 @@ Fixed issues have been moved to [FIXED_BUGS.md](FIXED_BUGS.md).
 
 
 
-## 27. Playlist fetch failures cached permanently
-`get_cached_playlists` stores the error response in the cache, so a transient fetch failure leaves the error cached until the TTL expires.
-```
-        except Exception as exc:  # pylint: disable=broad-exception-caught
-            logger.error("Failed to fetch playlists: %s", exc)
-            playlists_data = {"playlists": [], "error": str(exc)}
-        playlist_cache.set(cache_key, playlists_data, expire=CACHE_TTLS["playlists"])
-```
-【F:utils/helpers.py†L24-L31】
-
 ## 45. Last.fm tag failures repeatedly hit the API
 `get_lastfm_tags` returns an empty list on error but never caches the failure, causing repeated requests during outages.
 ```

--- a/FIXED_BUGS.md
+++ b/FIXED_BUGS.md
@@ -357,3 +357,21 @@ errors from marking tracks as permanently absent.
         return None
 ```
 【F:services/lastfm.py†L108-L112】
+
+## 27. Playlist fetch failures cached permanently
+*Fixed.* `get_cached_playlists` now only caches successful playlist fetches.
+```python
+    playlists_data = playlist_cache.get(cache_key)
+    if playlists_data is None:
+        try:
+            playlists_data = await fetch_audio_playlists(user_id)
+            playlist_cache.set(
+                cache_key, playlists_data, expire=CACHE_TTLS["playlists"]
+            )
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            logger.error("Failed to fetch playlists: %s", exc)
+            # Return the error response but avoid caching it so transient issues
+            # do not persist until the TTL expires
+            return {"playlists": [], "error": str(exc)}
+```
+【F:utils/helpers.py†L19-L35】


### PR DESCRIPTION
## Summary
- avoid caching playlist fetch failures
- move bug 27 to FIXED_BUGS

## Testing
- `pylint core api services utils`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68816a4681c48332bce6122d7f68781d