### PR TITLE
Fix Last.fm tag failure caching

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -5,15 +5,6 @@ Fixed issues have been moved to [FIXED_BUGS.md](FIXED_BUGS.md).
 
 
 
-## 45. Last.fm tag failures repeatedly hit the API
-`get_lastfm_tags` returns an empty list on error but never caches the failure, causing repeated requests during outages.
-```
-except Exception as exc:  # pylint: disable=broad-exception-caught
-    record_failure("lastfm")
-    logger.warning("Last.fm tag fetch failed for %s - %s: %s", title, artist, exc)
-    return []
-```
-【F:services/lastfm.py†L60-L68】
 ## 41. Mood weight constants stay stale after updates
 `LYRICS_WEIGHT`, `BPM_WEIGHT`, and `TAGS_WEIGHT` are set once from ``settings`` and never refreshed when the values change.
 ```

--- a/FIXED_BUGS.md
+++ b/FIXED_BUGS.md
@@ -375,3 +375,14 @@ errors from marking tracks as permanently absent.
             return {"playlists": [], "error": str(exc)}
 ```
 【F:utils/helpers.py†L19-L35】
+
+## 45. Last.fm tag failures repeatedly hit the API
+*Fixed.* `get_lastfm_tags` now caches an empty list when a request fails so repeated errors don't hammer the API.
+```python
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        record_failure("lastfm")
+        logger.warning("Last.fm tag fetch failed for %s - %s: %s", title, artist, exc)
+        lastfm_cache.set(cache_key, [], expire=CACHE_TTLS["lastfm"])
+        return []
+```
+【F:services/lastfm.py†L60-L67】

--- a/services/lastfm.py
+++ b/services/lastfm.py
@@ -65,6 +65,7 @@ async def get_lastfm_tags(title: str, artist: str) -> list[str]:
     except Exception as exc:  # pylint: disable=broad-exception-caught
         record_failure("lastfm")
         logger.warning("Last.fm tag fetch failed for %s - %s: %s", title, artist, exc)
+        lastfm_cache.set(cache_key, [], expire=CACHE_TTLS["lastfm"])
         return []
 
 


### PR DESCRIPTION
## Summary
- avoid repeated Last.fm requests when tag lookups fail
- move bug report to FIXED_BUGS.md

## Testing
- `pylint core api services utils`
- `PYTHONPATH=$PYTHONPATH:. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68816bad178083329674ef9c14af79b8