### PR TITLE
Fix mood weight constants refresh bug

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -5,15 +5,6 @@ Fixed issues have been moved to [FIXED_BUGS.md](FIXED_BUGS.md).
 
 
 
-## 41. Mood weight constants stay stale after updates
-`LYRICS_WEIGHT`, `BPM_WEIGHT`, and `TAGS_WEIGHT` are set once from ``settings`` and never refreshed when the values change.
-```
-LYRICS_WEIGHT = settings.lyrics_weight
-BPM_WEIGHT = settings.bpm_weight
-TAGS_WEIGHT = settings.tags_weight
-```
-【F:core/analysis.py†L419-L421】
-
 ## 21. Popularity thresholds remain stale after settings updates
 When `global_min_lfm` or `global_max_lfm` are changed in the UI, the
 module-level constants used by the analysis functions retain their original

--- a/FIXED_BUGS.md
+++ b/FIXED_BUGS.md
@@ -386,3 +386,24 @@ errors from marking tracks as permanently absent.
         return []
 ```
 【F:services/lastfm.py†L60-L67】
+
+## 41. Mood weight constants stay stale after updates
+*Fixed.* `combine_mood_scores` now reads weighting values from `settings` each
+time it runs, ensuring updates take effect immediately.
+
+```python
+    combined = {}
+    tags_weight = settings.tags_weight
+    bpm_weight = settings.bpm_weight
+    lyrics_weight = settings.lyrics_weight
+
+    for mood in MOOD_TAGS:
+        score = (
+            tags_weight * tag_scores.get(mood, 0)
+            + bpm_weight * bpm_scores.get(mood, 0)
+            + (lyrics_weight * lyrics_scores.get(mood, 0) if lyrics_scores else 0)
+        )
+        weighted = score * MOOD_WEIGHTS.get(mood, 1.0)
+        combined[mood] = weighted
+```
+【F:core/analysis.py†L492-L503】

--- a/core/analysis.py
+++ b/core/analysis.py
@@ -426,9 +426,6 @@ MOOD_WEIGHTS = {
 }
 
 
-LYRICS_WEIGHT = settings.lyrics_weight
-BPM_WEIGHT = settings.bpm_weight
-TAGS_WEIGHT = settings.tags_weight
 DEFAULT_LYRICS_CONFIDENCE = 1  # Confidence assigned to GPT-derived mood
 
 MOOD_MAPPING = {
@@ -493,11 +490,15 @@ def combine_mood_scores(
 
     # Combine with weighting:
     combined = {}
+    tags_weight = settings.tags_weight
+    bpm_weight = settings.bpm_weight
+    lyrics_weight = settings.lyrics_weight
+
     for mood in MOOD_TAGS:
         score = (
-            TAGS_WEIGHT * tag_scores.get(mood, 0)
-            + BPM_WEIGHT * bpm_scores.get(mood, 0)
-            + (LYRICS_WEIGHT * lyrics_scores.get(mood, 0) if lyrics_scores else 0)
+            tags_weight * tag_scores.get(mood, 0)
+            + bpm_weight * bpm_scores.get(mood, 0)
+            + (lyrics_weight * lyrics_scores.get(mood, 0) if lyrics_scores else 0)
         )
         weighted = score * MOOD_WEIGHTS.get(mood, 1.0)
         combined[mood] = weighted


### PR DESCRIPTION
## Summary
- remove stale mood weight constants
- calculate mood weightings from `settings` each call
- document bug fix in `FIXED_BUGS.md`
- remove bug entry from `BUGS.md`

## Testing
- `black .`
- `pylint core api services utils`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6882b041af588332a1f6ad133fbe1dc7