### PR TITLE
Fix stale popularity thresholds

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -5,19 +5,6 @@ Fixed issues have been moved to [FIXED_BUGS.md](FIXED_BUGS.md).
 
 
 
-## 21. Popularity thresholds remain stale after settings updates
-When `global_min_lfm` or `global_max_lfm` are changed in the UI, the
-module-level constants used by the analysis functions retain their original
-values. This causes all popularity calculations to keep using outdated
-thresholds.
-```
-settings: AppSettings = load_settings()
-...
-GLOBAL_MIN_LFM = settings.global_min_lfm
-GLOBAL_MAX_LFM = settings.global_max_lfm
-```
-【F:config.py†L191-L195】
-
 ## 22. Cache TTL configuration not refreshed
 `CACHE_TTLS` is set once at import time from `settings.cache_ttls`.
 Updating TTLs through the settings page does not propagate to existing caches.

--- a/FIXED_BUGS.md
+++ b/FIXED_BUGS.md
@@ -407,3 +407,23 @@ time it runs, ensuring updates take effect immediately.
         combined[mood] = weighted
 ```
 【F:core/analysis.py†L492-L503】
+
+## 21. Popularity thresholds remain stale after settings updates
+*Fixed.* Popularity calculations now read the Last.fm listener bounds from
+`settings` whenever they run instead of using constants set at import time.
+
+```python
+def get_global_min_lfm() -> int:
+    return settings.global_min_lfm
+
+def get_global_max_lfm() -> int:
+    return settings.global_max_lfm
+```
+【F:config.py†L195-L202】
+
+```python
+norm_lfm = normalize_popularity_log(
+    raw_lfm, get_global_min_lfm(), get_global_max_lfm()
+)
+```
+【F:core/analysis.py†L284-L289】

--- a/config.py
+++ b/config.py
@@ -191,5 +191,12 @@ def save_settings(s: AppSettings) -> None:
 settings: AppSettings = load_settings()
 logging.getLogger("playlist-pilot").debug("settings loaded: %s", settings.dict())
 
-GLOBAL_MIN_LFM = settings.global_min_lfm
-GLOBAL_MAX_LFM = settings.global_max_lfm
+
+def get_global_min_lfm() -> int:
+    """Return the current minimum Last.fm listener threshold."""
+    return settings.global_min_lfm
+
+
+def get_global_max_lfm() -> int:
+    """Return the current maximum Last.fm listener threshold."""
+    return settings.global_max_lfm

--- a/core/analysis.py
+++ b/core/analysis.py
@@ -6,7 +6,7 @@ from statistics import mean
 import math
 import logging
 import re
-from config import settings, GLOBAL_MIN_LFM, GLOBAL_MAX_LFM
+from config import settings, get_global_min_lfm, get_global_max_lfm
 
 logger = logging.getLogger("playlist-pilot")
 
@@ -284,7 +284,9 @@ def add_combined_popularity(
         raw_lfm = track.get("popularity")
         raw_jf = track.get("jellyfin_play_count")
         norm_lfm = (
-            normalize_popularity_log(raw_lfm, GLOBAL_MIN_LFM, GLOBAL_MAX_LFM)
+            normalize_popularity_log(
+                raw_lfm, get_global_min_lfm(), get_global_max_lfm()
+            )
             if raw_lfm is not None
             else None
         )

--- a/core/playlist.py
+++ b/core/playlist.py
@@ -16,7 +16,7 @@ import re
 
 import httpx
 
-from config import settings, GLOBAL_MIN_LFM, GLOBAL_MAX_LFM
+from config import settings, get_global_min_lfm, get_global_max_lfm
 from core.analysis import (
     mood_scores_from_bpm_data,
     mood_scores_from_lastfm_tags,
@@ -561,7 +561,9 @@ async def enrich_jellyfin_playlist(
     for t in enriched:
         raw_lfm = t.get("popularity")
         raw_jf = t.get("jellyfin_play_count")
-        norm_lfm = normalize_popularity_log(raw_lfm, GLOBAL_MIN_LFM, GLOBAL_MAX_LFM)
+        norm_lfm = normalize_popularity_log(
+            raw_lfm, get_global_min_lfm(), get_global_max_lfm()
+        )
         norm_jf = normalize_popularity(raw_jf, 0, max_jf)
         logger.debug("%s", t["title"])
         combined = combined_popularity_score(norm_lfm, norm_jf)


### PR DESCRIPTION
## Summary
- refresh global popularity thresholds dynamically
- document fix for stale popularity bounds in `FIXED_BUGS.md`
- remove bug entry from `BUGS.md`

## Testing
- `black .`
- `pylint core api services utils`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_6882b2c309508332b87f0a1e01b1899e