### PR TITLE
Fix cache TTL refresh issue

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -5,15 +5,6 @@ Fixed issues have been moved to [FIXED_BUGS.md](FIXED_BUGS.md).
 
 
 
-## 22. Cache TTL configuration not refreshed
-`CACHE_TTLS` is set once at import time from `settings.cache_ttls`.
-Updating TTLs through the settings page does not propagate to existing caches.
-```
-# TTL configuration (in seconds) for each named cache
-CACHE_TTLS = settings.cache_ttls
-```
-【F:utils/cache_manager.py†L49-L50】
-
 ## 24. Imported M3U files must be UTF-8
 `import_m3u_as_history_entry` opens playlists with a fixed UTF‑8 encoding.
 Files encoded differently trigger `UnicodeDecodeError` and abort the import.

--- a/FIXED_BUGS.md
+++ b/FIXED_BUGS.md
@@ -427,3 +427,17 @@ norm_lfm = normalize_popularity_log(
 )
 ```
 【F:core/analysis.py†L284-L289】
+
+## 22. Cache TTL configuration not refreshed
+*Fixed.* Updating settings now refreshes the shared cache TTL dictionary so new cache entries honor the changed values.
+
+```python
+    settings.cache_ttls = form_data.cache_ttls
+    # Update shared cache TTLs in-place so other modules
+    # that imported the dictionary see the new values
+    from utils import cache_manager  # import here to avoid circular dependency
+
+    cache_manager.CACHE_TTLS.clear()
+    cache_manager.CACHE_TTLS.update(settings.cache_ttls)
+```
+【F:api/routes.py†L383-L389】

--- a/api/routes.py
+++ b/api/routes.py
@@ -381,6 +381,12 @@ async def update_settings(
     settings.global_min_lfm = form_data.global_min_lfm
     settings.global_max_lfm = form_data.global_max_lfm
     settings.cache_ttls = form_data.cache_ttls
+    # Update shared cache TTLs in-place so other modules
+    # that imported the dictionary see the new values
+    from utils import cache_manager  # import here to avoid circular dependency
+
+    cache_manager.CACHE_TTLS.clear()
+    cache_manager.CACHE_TTLS.update(settings.cache_ttls)
     settings.getsongbpm_base_url = form_data.getsongbpm_base_url
     settings.getsongbpm_headers = form_data.getsongbpm_headers
     settings.http_timeout_short = form_data.http_timeout_short

--- a/utils/cache_manager.py
+++ b/utils/cache_manager.py
@@ -47,4 +47,6 @@ library_cache = Cache(BASE_CACHE / "full_library")
 
 
 # TTL configuration (in seconds) for each named cache
-CACHE_TTLS = settings.cache_ttls
+# This copy is updated when settings change so other modules
+# using the dict see refreshed values.
+CACHE_TTLS = dict(settings.cache_ttls)


### PR DESCRIPTION
## Summary
- ensure CACHE_TTLS updates when settings are changed
- copy TTLs in cache manager so updates can modify dict in-place
- document fix in FIXED_BUGS and remove the open bug from BUGS

## Testing
- `pip install -r requirements.txt`
- `pip install pylint black pytest`
- `black .`
- `pylint core api services utils`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_6882b5791dd083329e32bc06f43cb445