### PR TITLE
Fix pylint import warning

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -383,7 +383,8 @@ async def update_settings(
     settings.cache_ttls = form_data.cache_ttls
     # Update shared cache TTLs in-place so other modules
     # that imported the dictionary see the new values
-    from utils import cache_manager  # import here to avoid circular dependency
+    # Import lazily to avoid a circular dependency
+    from utils import cache_manager  # pylint: disable=import-outside-toplevel
 
     cache_manager.CACHE_TTLS.clear()
     cache_manager.CACHE_TTLS.update(settings.cache_ttls)


### PR DESCRIPTION
## Summary
- annotate inline cache_manager import in `api/routes.py`
- run black, pylint, and tests

## Testing
- `black .`
- `pylint core api services utils`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_6882bae57e588332a98298241f3180ff