### PR TITLE
Fix suggest request parsing bug

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -5,16 +5,6 @@ Fixed issues have been moved to [FIXED_BUGS.md](FIXED_BUGS.md).
 
 
 
-## 32. Suggest request parsing fails for list payloads
-`parse_suggest_request` converts the `tracks` field to a string before JSON parsing. If the form sends a list object, the resulting string uses single quotes and cannot be decoded.
-```
-    tracks_raw = data.get("tracks", "[]")
-    tracks_raw_str = str(tracks_raw)
-    ...
-    tracks = json.loads(tracks_raw_str)
-```
-【F:utils/helpers.py†L44-L52】
-
 ## 35. `normalize_genre` crashes on ``None`` input
 The helper assumes a string and calls `.strip()`, raising ``AttributeError`` when passed ``None``.
 ```

--- a/FIXED_BUGS.md
+++ b/FIXED_BUGS.md
@@ -452,3 +452,27 @@ norm_lfm = normalize_popularity_log(
         ]
 ```
 【F:core/m3u.py†L186-L189】
+
+## 32. Suggest request parsing fails for list payloads
+*Fixed.* `parse_suggest_request` now handles list objects directly and only decodes JSON when the ``tracks`` value is a string.
+
+```python
+    tracks_raw = data.get("tracks", "[]")
+    logger.info("tracks_raw: %s", str(tracks_raw)[:100])
+    playlist_name = str(data.get("playlist_name", ""))
+    text_summary = str(data.get("text_summary", ""))
+
+    if isinstance(tracks_raw, str):
+        tracks_raw_str = tracks_raw
+        try:
+            tracks = json.loads(tracks_raw_str)
+        except json.JSONDecodeError:
+            logger.warning("Failed to decode tracks JSON from form.")
+            tracks = []
+    elif isinstance(tracks_raw, (list, tuple)):
+        tracks = list(tracks_raw)
+    else:
+        logger.warning("Unexpected tracks type: %s", type(tracks_raw))
+        tracks = []
+```
+【F:utils/helpers.py†L49-L67】

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -47,15 +47,21 @@ async def parse_suggest_request(request: Request) -> tuple[list[dict], str, str]
     """Extract tracks and related fields from a suggestion form request."""
     data = await request.form()
     tracks_raw = data.get("tracks", "[]")
-    tracks_raw_str = str(tracks_raw)
-    logger.info("tracks_raw: %s", tracks_raw_str[:100])
+    logger.info("tracks_raw: %s", str(tracks_raw)[:100])
     playlist_name = str(data.get("playlist_name", ""))
     text_summary = str(data.get("text_summary", ""))
 
-    try:
-        tracks = json.loads(tracks_raw_str)
-    except json.JSONDecodeError:
-        logger.warning("Failed to decode tracks JSON from form.")
+    if isinstance(tracks_raw, str):
+        tracks_raw_str = tracks_raw
+        try:
+            tracks = json.loads(tracks_raw_str)
+        except json.JSONDecodeError:
+            logger.warning("Failed to decode tracks JSON from form.")
+            tracks = []
+    elif isinstance(tracks_raw, (list, tuple)):
+        tracks = list(tracks_raw)
+    else:
+        logger.warning("Unexpected tracks type: %s", type(tracks_raw))
         tracks = []
 
     return tracks, playlist_name, text_summary


### PR DESCRIPTION
## Summary
- handle list objects in `parse_suggest_request`
- move bug #32 to `FIXED_BUGS.md`

## Testing
- `black .`
- `pylint core api services utils`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688351919f688332afbd95e911fd95a8