### PR TITLE
Fix normalize_genre None input

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -5,14 +5,6 @@ Fixed issues have been moved to [FIXED_BUGS.md](FIXED_BUGS.md).
 
 
 
-## 35. `normalize_genre` crashes on ``None`` input
-The helper assumes a string and calls `.strip()`, raising ``AttributeError`` when passed ``None``.
-```
-def normalize_genre(raw: str) -> str:
-    cleaned = raw.strip().lower()
-    return GENRE_SYNONYMS.get(cleaned, cleaned)
-```
-【F:core/playlist.py†L413-L416】
 ## 38. Template directory bound to current working directory
 `Jinja2Templates` uses the relative path ``"templates"`` so running the app from another directory cannot locate the HTML files.
 ```

--- a/FIXED_BUGS.md
+++ b/FIXED_BUGS.md
@@ -476,3 +476,16 @@ norm_lfm = normalize_popularity_log(
         tracks = []
 ```
 【F:utils/helpers.py†L49-L67】
+
+## 35. `normalize_genre` crashes on ``None`` input
+*Fixed.* The helper now returns an empty string when passed ``None`` or another falsy value.
+
+```python
+def normalize_genre(raw: str | None) -> str:
+    """Map genre synonyms to canonical names."""
+    if not raw:
+        return ""
+    cleaned = str(raw).strip().lower()
+    return GENRE_SYNONYMS.get(cleaned, cleaned)
+```
+【F:core/playlist.py†L413-L418】

--- a/core/playlist.py
+++ b/core/playlist.py
@@ -410,9 +410,11 @@ GENRE_SYNONYMS = {
 }
 
 
-def normalize_genre(raw: str) -> str:
+def normalize_genre(raw: str | None) -> str:
     """Map genre synonyms to canonical names."""
-    cleaned = raw.strip().lower()
+    if not raw:
+        return ""
+    cleaned = str(raw).strip().lower()
     return GENRE_SYNONYMS.get(cleaned, cleaned)
 
 

--- a/tests/test_playlist_helpers.py
+++ b/tests/test_playlist_helpers.py
@@ -85,6 +85,11 @@ def test_infer_decade_and_normalize_genre():
     assert normalize_genre("Alternative Rock") == "alternative"
 
 
+def test_normalize_genre_none():
+    """``normalize_genre`` should return an empty string for ``None`` input."""
+    assert normalize_genre(None) == ""
+
+
 def test_estimate_tempo_basic():
     """Ensure tempo estimation falls back to expected defaults."""
     assert estimate_tempo(250, "electronic") == 140


### PR DESCRIPTION
## Summary
- handle None safely in `normalize_genre`
- test for None handling
- move bug 35 to fixed list

## Testing
- `black .`
- `pylint core api services utils`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688353f633648332a054f5b4f7a3b2cf