### PR TITLE
Move mood badge macro to shared macros

### DIFF
--- a/templates/analysis_result.html
+++ b/templates/analysis_result.html
@@ -1,32 +1,6 @@
 {% extends "base.html" %}
 {% block title %}Analysis Results{% endblock %}
 
-{% macro mood_badge(mood, confidence) %}
-  {% if mood %}
-    {% set badge_class = "" %}
-    {% set confidence_text = "" %}
-    {% if confidence >= 0.66 %}
-      {% set badge_class = "inline-block px-2 py-1 rounded-full text-sm bg-blue-500 text-white" %}
-      {% set confidence_text = "Very High confidence" %}
-    {% elif confidence >= 0.4 %}
-      {% set badge_class = "inline-block px-2 py-1 rounded-full text-sm bg-green-600 text-white" %}
-      {% set confidence_text = "High confidence" %}
-    {% elif confidence >= 0.2 %}
-      {% set badge_class = "inline-block px-2 py-1 rounded-full text-sm bg-yellow-400 text-gray-900" %}
-      {% set confidence_text = "Moderate confidence" %}
-    {% else %}
-      {% set badge_class = "inline-block px-2 py-1 rounded-full text-sm bg-gray-500 text-white" %}
-      {% set confidence_text = "Low confidence" %}
-    {% endif %}
-    <span class="{{ badge_class }}"
-          data-tippy-content="Mood: {{ mood | capitalize }} — {{ confidence_text }} ({{ confidence | round(2) }})">
-      {{ mood | capitalize }}
-    </span>
-  {% else %}
-    <span class="text-gray-400">Unknown</span>
-  {% endif %}
-{% endmacro %}
-
 {% block content %}
 <main class="container mx-auto max-w-5xl p-2">
 <h1 class="text-2xl font-bold mb-6 flex items-center space-x-2">
@@ -244,7 +218,7 @@
               <td class="p-2 border-b">
                 <span class="{% if track.genre == 'Unknown' %}text-red-600 dark:text-red-400 font-semibold{% endif %}">{{ track.genre | capitalize }}</span>
               </td>
-              <td class="p-2 border-b">{{ mood_badge(track.mood, track.mood_confidence) }}</td>
+              <td class="p-2 border-b">{{ macros.mood_badge(track.mood, track.mood_confidence) }}</td>
               <td class="p-2 border-b">{{ track.tempo }}</td>
               <td class="p-2 border-b">
                 <span {% if track.year_flag %} class="text-yellow-600 dark:text-yellow-400 font-semibold" data-tippy-content="Release year appears unreliable {{ track.year_flag }}" {% endif %}>

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -9,3 +9,29 @@
     <a href="{{ href }}" class="{% if current.startswith(href) %}text-blue-600 underline{% endif %}">{{ label }}</a>
   {% endfor %}
 {% endmacro %}
+
+{% macro mood_badge(mood, confidence) %}
+  {% if mood %}
+    {% set badge_class = "" %}
+    {% set confidence_text = "" %}
+    {% if confidence >= 0.66 %}
+      {% set badge_class = "inline-block px-2 py-1 rounded-full text-sm bg-blue-500 text-white" %}
+      {% set confidence_text = "Very High confidence" %}
+    {% elif confidence >= 0.4 %}
+      {% set badge_class = "inline-block px-2 py-1 rounded-full text-sm bg-green-600 text-white" %}
+      {% set confidence_text = "High confidence" %}
+    {% elif confidence >= 0.2 %}
+      {% set badge_class = "inline-block px-2 py-1 rounded-full text-sm bg-yellow-400 text-gray-900" %}
+      {% set confidence_text = "Moderate confidence" %}
+    {% else %}
+      {% set badge_class = "inline-block px-2 py-1 rounded-full text-sm bg-gray-500 text-white" %}
+      {% set confidence_text = "Low confidence" %}
+    {% endif %}
+    <span class="{{ badge_class }}"
+          data-tippy-content="Mood: {{ mood | capitalize }} — {{ confidence_text }} ({{ confidence | round(2) }})">
+      {{ mood | capitalize }}
+    </span>
+  {% else %}
+    <span class="text-gray-400">Unknown</span>
+  {% endif %}
+{% endmacro %}

--- a/templates/results.html
+++ b/templates/results.html
@@ -54,7 +54,7 @@
 
   <ul class="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-1 text-sm text-gray-700 dark:text-gray-300">
     {% if s.genre %}<li>🎵 <strong>Genre:</strong> {{ s.genre }}</li>{% endif %}
-    {% if s.mood %}<li>🧠 <strong>Mood:</strong> {{ s.mood }}</li>{% endif %}
+    {% if s.mood %}<li>🧠 <strong>Mood:</strong> {{ macros.mood_badge(s.mood, s.mood_confidence) }}</li>{% endif %}
 
     {% if s.bpm %}
       <li>⏱️ <strong>BPM:</strong>


### PR DESCRIPTION
## Summary
- relocate the mood_badge macro into `macros.html`
- use the shared macro from `analysis_result.html` and `results.html`
- keep base template importing `macros.html`

## Testing
- `black .`
- `pylint core api services utils`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68836938923083328688a0679c71fd54