### PR TITLE
Fix genre check in outlier detection

### DIFF
--- a/core/analysis.py
+++ b/core/analysis.py
@@ -139,11 +139,12 @@ def detect_outliers(tracks: List[dict], summary: dict) -> List[dict]:
         ):
             reasons.append("tempo")
 
-        # Genre mismatch (excluding 'Unknown')
+        # Genre mismatch only when a dominant genre is known
         genre = t.get("genre")
         if (
             isinstance(genre, str)
             and isinstance(dominant_genre, str)
+            and dominant_genre.lower() != "unknown"
             and genre.lower() != dominant_genre.lower()
         ):
             reasons.append("genre")


### PR DESCRIPTION
## Summary
- avoid flagging genre mismatches when dominant genre is unknown
- update comment describing genre comparison

## Testing
- `black .`
- `pylint core api services utils`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68836ba0a5288332a0e6c1ec1e96cff0