### PR TITLE
Refactor template styles

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -6,60 +6,6 @@ body {
   color: #222;
 }
 
-.container {
-  max-width: 900px;
-  margin: 0 auto;
-  padding: 1rem;
-}
-
-.site-header {
-  background-color: #333;
-  color: #fff;
-  padding: 1rem 0;
-  text-align: center;
-}
-
-.site-title {
-  margin: 0;
-  font-size: 1.75rem;
-}
-
-.navbar {
-  background-color: #f4f4f4;
-  padding: 0.5rem;
-  border-top: 1px solid #ddd;
-  border-bottom: 1px solid #ddd;
-  display: flex;
-  justify-content: center;
-  gap: 1rem;
-  flex-wrap: wrap;
-}
-
-.navbar a {
-  text-decoration: none;
-  color: #333;
-  font-weight: bold;
-}
-
-.navbar a:hover {
-  color: #007bff;
-}
-
-.site-footer {
-  margin-top: 3rem;
-  background: #eee;
-  text-align: center;
-  padding: 1rem;
-  font-size: 0.9rem;
-  color: #555;
-  border-top: 1px solid #ccc;
-}
-
-.settings-form {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
 
 ul {
   padding-left: 1.25rem;

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,28 +5,24 @@
   <title>{% block title %}Playlist Pilot{% endblock %}</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="/static/style.css">
-<script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="bg-gray-100 text-gray-900 dark:bg-gray-900 dark:text-gray-100">
 {% import "macros.html" as macros %}
-  <header class="site-header">
-    <div class="container">
-      <h1 class="site-title">🎶 Playlist Pilot</h1>
-    </div>
+  <header class="bg-gray-800 text-white text-center py-4">
+    <h1 class="text-2xl font-bold">🎶 Playlist Pilot</h1>
   </header>
 
-  <nav class="navbar sticky top-0 bg-white shadow z-50 flex gap-4 p-2">
+  <nav class="sticky top-0 bg-white dark:bg-gray-800 shadow z-50 flex gap-4 p-2 justify-center">
     {{ macros.nav(request) }}
   </nav>
 
-  <main class="container">
+  <main class="max-w-4xl mx-auto p-4">
     {% block content %}{% endblock %}
   </main>
 
-  <footer class="site-footer">
-    <div class="container">
-      <p>Playlist Pilot — Curate your soundtrack.</p>
-    </div>
+  <footer class="mt-8 bg-gray-200 dark:bg-gray-800 text-center p-4 text-sm text-gray-700 dark:text-gray-300">
+    <p>Playlist Pilot — Curate your soundtrack.</p>
   </footer>
 
 </body>

--- a/templates/error.html
+++ b/templates/error.html
@@ -1,14 +1,12 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Error</title>
-</head>
-<body>
-    <h1>Error Occurred</h1>
-    <p>An error occurred while processing your request.</p>
-    <p><strong>Error Details:</strong> {{ error }}</p>
-    <a href="/">Go Back to Home</a>
-</body>
-</html>
+{% extends "base.html" %}
+{% block title %}Error{% endblock %}
+
+{% block content %}
+<div class="max-w-xl mx-auto p-4 text-center">
+  <h1 class="text-2xl font-bold mb-4">⚠️ Error Occurred</h1>
+  <p class="mb-2">An error occurred while processing your request.</p>
+  <p class="mb-4 text-red-600"><strong>Error Details:</strong> {{ error }}</p>
+  <a href="/" class="text-blue-600 underline">Go Back to Home</a>
+</div>
+{% endblock %}
+

--- a/templates/history.html
+++ b/templates/history.html
@@ -68,7 +68,7 @@
       <span class='inline-block transition-transform duration-300 rotate-0 group-[.expanded]:rotate-90'>▶</span> Show Tracks
     </button>
 
-    <form action="/history/delete" method="post" style="display:inline;" onsubmit="return confirm('Are you sure you want to delete this playlist?');">
+    <form action="/history/delete" method="post" class="inline" onsubmit="return confirm('Are you sure you want to delete this playlist?');">
       <input type="hidden" name="entry_id" value="{{ entry.id }}">
       <button type="submit" aria-label="Delete playlist {{ entry.label }}" class="text-sm px-2 py-0.5 bg-red-100 text-red-700 rounded hover:bg-red-200">
         🗑️ Delete

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -6,7 +6,10 @@
     ('/history', '🕓 History'),
     ('/settings', '⚙️ Settings')]
   %}
-    <a href="{{ href }}" class="{% if current.startswith(href) %}text-blue-600 underline{% endif %}">{{ label }}</a>
+    <a href="{{ href }}"
+       class="px-2 py-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700 {% if current.startswith(href) %}text-blue-600 underline{% else %}text-gray-800 dark:text-gray-100{% endif %}">
+      {{ label }}
+    </a>
   {% endfor %}
 {% endmacro %}
 

--- a/templates/playlists.html
+++ b/templates/playlists.html
@@ -1,24 +1,28 @@
 {% extends "base.html" %}
+{% block title %}Playlists{% endblock %}
+
 {% block content %}
-    <h1>All Playlists</h1>
-    <ul>
-        {% if playlists %}
-            {% for playlist in playlists %}
-                <li>
-                    <h3>{{ playlist.name }}</h3>
-                    <ul>
-                        {% if playlist.tracks %}
-                            {% for track in playlist.tracks %}
-                                <li>{{ track.song }} - {{ track.artist }} (Album: {{ track.album }}, Year: {{ track.release_year }})</li>
-                            {% endfor %}
-                        {% else %}
-                            <li>No tracks available for this playlist.</li>
-                        {% endif %}
-                    </ul>
-                </li>
-            {% endfor %}
-        {% else %}
-            <li>No playlists available.</li>
-        {% endif %}
-    </ul>
+<div class="max-w-3xl mx-auto p-4">
+  <h1 class="text-2xl font-bold mb-4">All Playlists</h1>
+  <ul class="space-y-4">
+    {% if playlists %}
+      {% for playlist in playlists %}
+        <li class="bg-white dark:bg-gray-800 p-4 rounded shadow">
+          <h3 class="font-semibold mb-2">{{ playlist.name }}</h3>
+          <ul class="list-disc list-inside space-y-1 text-sm">
+            {% if playlist.tracks %}
+              {% for track in playlist.tracks %}
+                <li>{{ track.song }} - {{ track.artist }} (Album: {{ track.album }}, Year: {{ track.release_year }})</li>
+              {% endfor %}
+            {% else %}
+              <li>No tracks available for this playlist.</li>
+            {% endif %}
+          </ul>
+        </li>
+      {% endfor %}
+    {% else %}
+      <li>No playlists available.</li>
+    {% endif %}
+  </ul>
+</div>
 {% endblock %}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -37,7 +37,7 @@
     </div>
   {% endif %}
 
-  <form method="post" class="space-y-6 bg-white dark:bg-gray-700 p-6 rounded shadow settings-form">
+  <form method="post" class="space-y-6 bg-white dark:bg-gray-700 p-6 rounded shadow flex flex-col gap-4">
 
     <div class="grid gap-6 md:grid-cols-2">
 

--- a/templates/unused/library_suggest.html
+++ b/templates/unused/library_suggest.html
@@ -1,47 +1,50 @@
 {% extends "base.html" %}
+{% block title %}Library Suggestions{% endblock %}
+
 {% block content %}
+<div class="max-w-xl mx-auto p-4">
+  <h1 class="text-2xl font-bold mb-4">Library Playlist Suggestions</h1>
 
+  {% if error %}
+    <p class="text-red-600 mb-2">Error: {{ error }}</p>
+  {% endif %}
 
-    <h1>Library Playlist Suggestions</h1>
+  <form method="post" class="space-y-4 mb-4">
+    <div>
+      <label for="mood" class="block font-semibold">Mood:</label>
+      <select name="mood" id="mood" class="w-full p-2 border border-gray-300 rounded">
+        <option value="general" {% if mood == 'general' %}selected{% endif %}>General</option>
+        <option value="happy" {% if mood == 'happy' %}selected{% endif %}>Happy</option>
+        <option value="sad" {% if mood == 'sad' %}selected{% endif %}>Sad</option>
+        <option value="relaxed" {% if mood == 'relaxed' %}selected{% endif %}>Relaxed</option>
+        <option value="energetic" {% if mood == 'energetic' %}selected{% endif %}>Energetic</option>
+      </select>
+    </div>
+    <div>
+      <label for="genres" class="block font-semibold">Genres:</label>
+      <input type="text" name="genres" id="genres" value="{{ genres }}" placeholder="e.g., Rock, Pop, Jazz" class="w-full p-2 border border-gray-300 rounded">
+    </div>
+    <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">Generate Suggestions</button>
+  </form>
 
-    {% if error %}
-        <p style="color: red;">Error: {{ error }}</p>
-    {% endif %}
+  <h2 class="text-xl font-semibold mb-2">Suggested Playlists</h2>
+  {% if suggestions %}
+    <ul class="list-disc list-inside space-y-1">
+      {% for suggestion in suggestions %}
+        <li>
+          {{ suggestion.text }}
+          {% if suggestion.youtube_url %}
+            - <a href="{{ suggestion.youtube_url }}" target="_blank" class="text-blue-600 underline">Listen on YouTube</a>
+          {% endif %}
+        </li>
+      {% endfor %}
+    </ul>
+  {% else %}
+    <p>No suggestions available.</p>
+  {% endif %}
 
-    <!-- Form for mood and genre selection -->
-    <form method="post">
-        <label for="mood">Mood:</label>
-        <select name="mood" id="mood">
-            <option value="general" {% if mood == 'general' %}selected{% endif %}>General</option>
-            <option value="happy" {% if mood == 'happy' %}selected{% endif %}>Happy</option>
-            <option value="sad" {% if mood == 'sad' %}selected{% endif %}>Sad</option>
-            <option value="relaxed" {% if mood == 'relaxed' %}selected{% endif %}>Relaxed</option>
-            <option value="energetic" {% if mood == 'energetic' %}selected{% endif %}>Energetic</option>
-        </select>
-
-        <label for="genres">Genres:</label>
-        <input type="text" name="genres" id="genres" value="{{ genres }}" placeholder="e.g., Rock, Pop, Jazz">
-
-        <button type="submit">Generate Suggestions</button>
-    </form>
-
-    <h2>Suggested Playlists</h2>
-    {% if suggestions %}
-        <ul>
-            {% for suggestion in suggestions %}
-                <li>{{ suggestion.text }} 
-                    {% if suggestion.youtube_url %}
-                        - <a href="{{ suggestion.youtube_url }}" target="_blank">Listen on YouTube</a>
-                    {% endif %}
-                </li>
-            {% endfor %}
-        </ul>
-    {% else %}
-        <p>No suggestions available.</p>
-    {% endif %}
-
-    {% if download_link %}
-        <a href="{{ download_link }}" download>Download Playlist</a>
-    {% endif %}
-
+  {% if download_link %}
+    <a href="{{ download_link }}" download class="text-blue-600 underline">Download Playlist</a>
+  {% endif %}
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- remove custom layout rules from `style.css`
- convert base layout and nav to Tailwind
- modernize error and playlists templates
- tweak settings form and library_suggest layout
- clean up inline style in history

## Testing
- `black .`
- `pylint core api services utils`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68837e45cfd483328a95d8e6f298bb79