### PR TITLE
Change navbar active state styling

### DIFF
--- a/templates/macros.html
+++ b/templates/macros.html
@@ -11,10 +11,10 @@
     {% else %}
       {% set is_active = current.startswith(href) %}
     {% endif %}
-    <a href="{{ href }}"
-       class="px-2 py-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700 {% if is_active %}underline text-white{% else %}text-gray-800 dark:text-gray-100{% endif %}">
-      {{ label }}
-    </a>
+      <a href="{{ href }}"
+         class="px-2 py-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700 {% if is_active %}bg-blue-600 text-white{% else %}text-gray-800 dark:text-gray-100{% endif %}">
+        {{ label }}
+      </a>
   {% endfor %}
 {% endmacro %}
 


### PR DESCRIPTION
## Summary
- show a blue background instead of an underline for the active navbar link

## Testing
- `black .`
- `pylint core api services utils`
- `pytest` *(fails: ModuleNotFoundError: No module named 'core')*

------
https://chatgpt.com/codex/tasks/task_e_6883b5167d2c8332841973626d0f1032