### PR TITLE
Fix settings layout on mobile

### DIFF
--- a/templates/settings.html
+++ b/templates/settings.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
 
-<div class="mx-auto p-4">
+<div class="max-w-screen-x1 mx-auto p-4">
 
   <h1 class="text-2xl font-bold flex justify-between items-center mb-1">
     ⚙️ Settings
@@ -37,12 +37,12 @@
     </div>
   {% endif %}
 
-  <form method="post" class="space-y-6 bg-white dark:bg-gray-700 p-6 rounded shadow flex flex-col gap-4">
+  <form method="post" class="space-y-6 bg-white dark:bg-gray-700 p-6 rounded shadow flex flex-col gap-4 w-full">
 
-    <div class="grid gap-6 md:grid-cols-2">
+    <div class="grid gap-6 md:grid-cols-2 w-full">
 
     <!-- 🎬 Jellyfin Section -->
-    <fieldset class="mb-4 border border-gray-200 dark:border-gray-600 p-4 rounded">
+    <fieldset class="mb-4 border border-gray-200 dark:border-gray-600 p-4 rounded w-full">
       <legend class="px-2 text-lg font-semibold text-gray-800 dark:text-gray-100">🎬 Jellyfin Integration</legend>
 
       <div class="space-y-4">
@@ -72,7 +72,7 @@
     </fieldset>
 
     <!-- 🔑 API Keys Section -->
-    <fieldset class="mb-4 border border-gray-200 dark:border-gray-600 p-4 rounded">
+    <fieldset class="mb-4 border border-gray-200 dark:border-gray-600 p-4 rounded w-full">
       <legend class="px-2 text-lg font-semibold text-gray-800 dark:text-gray-100">🔑 API Keys</legend>
 
       <div class="space-y-4">


### PR DESCRIPTION
## Summary
- ensure settings fieldsets use full width on small screens
- make settings container responsive

## Testing
- `black .`
- `pylint core api services utils`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_6883b629ba648332a0f189f98c8e4c17