### PR TITLE
Add playlist order suggestions using GPT

### DIFF
--- a/Docs/api_reference.md
+++ b/Docs/api_reference.md
@@ -10,6 +10,7 @@ The table below summarises the main endpoints exposed by Playlist Pilot. All end
 | POST | `/analyze/result` | Display analysis results |
 | POST | `/analyze/export-m3u` | Export analyzed tracks as M3U |
 | POST | `/suggest-playlist` | Suggest a playlist from analysis results |
+| POST | `/suggest-order` | Get a recommended track order |
 | GET | `/compare` | Display comparison form |
 | POST | `/compare` | Compare two playlists |
 | GET | `/history` | View past GPT suggestions |

--- a/Docs/usage_guide.md
+++ b/Docs/usage_guide.md
@@ -8,7 +8,8 @@ This document provides a quick walkthrough of the typical workflow once Playlist
 2. On the home page you will be prompted to select a playlist source (either Jellyfin or History) and to select a Playlist to analyze.
 3. Click **Analyze** and Playlist-Pilot will provide you with an analysis of that playlist including a Summary, suggested tracks to remove, stats about the decade, mood, popularity and tempo of the tracks and then a track by track listing.
 4. Click "Suggest Similar Playlist" and Playlist Pilot will use GPT to suggest additional tracks with a similar theme, mood etc.
-5. Review the suggestions, edit any tracks if needed and press **Save** to create the playlist in Jellyfin. (not yet available)
+5. Click "Suggest Playlist Order" to get a recommended track sequence for the analyzed playlist.
+6. Review the suggestions, edit any tracks if needed and press **Save** to create the playlist in Jellyfin. (not yet available)
 
 You can also download the results as an `.m3u` file from the history page.
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -67,6 +67,7 @@ from services import jellyfin
 from services.gpt import (
     generate_playlist_analysis_summary,
     fetch_gpt_suggestions,
+    fetch_order_suggestions,
     fetch_openai_models,
 )
 from services.jellyfin import (
@@ -714,6 +715,21 @@ async def suggest_from_analyzed(request: Request):
             "Average_BPM": int(summary["tempo_avg"]),
             "Popularity": int(summary["avg_popularity"]),
             "Decades": summary["decades"].keys(),
+        },
+    )
+
+
+@router.post("/suggest-order")
+async def suggest_order_from_analyzed(request: Request):
+    """Return a recommended track order from GPT."""
+    tracks, playlist_name, text_summary = await parse_suggest_request(request)
+    ordered = await fetch_order_suggestions(tracks, text_summary)
+    return templates.TemplateResponse(
+        "order_results.html",
+        {
+            "request": request,
+            "ordered_tracks": ordered,
+            "playlist_name": playlist_name,
         },
     )
 

--- a/templates/analysis_result.html
+++ b/templates/analysis_result.html
@@ -33,6 +33,12 @@
   <input type="hidden" name="playlist_name" value="{{ playlist_name | tojson | forceescape }}">
   <button type="submit" class="text-md px-2 py-0.5 bg-blue-100 text-blue-800 rounded hover:bg-blue-200"  >Suggest Similar Playlist</button>
 </form>
+<form action="/suggest-order" method="post" class="mt-2" onsubmit="showSpinner()">
+  <input type="hidden" name="text_summary" value="{{ gpt_summary | tojson | forceescape }}">
+  <input type="hidden" name="tracks" value="{{ tracks | tojson | forceescape }}">
+  <input type="hidden" name="playlist_name" value="{{ playlist_name | tojson | forceescape }}">
+  <button type="submit" class="text-md px-2 py-0.5 bg-green-100 text-green-800 rounded hover:bg-green-200"  >Suggest Playlist Order</button>
+</form>
     {% else %}
       <p class="text-gray-400 italic">AI summary not available.</p>
     {% endif %}

--- a/templates/order_results.html
+++ b/templates/order_results.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+{% block title %}Playlist Order Suggestion{% endblock %}
+{% block content %}
+<main class="container mx-auto p-4">
+  <h1 class="text-2xl font-bold mb-4">Recommended Order for {{ playlist_name }}</h1>
+  <div class="bg-white dark:bg-gray-800 p-4 rounded shadow">
+    <ol class="list-decimal list-inside space-y-1">
+      {% for t in ordered_tracks %}
+        <li>{{ t.title }} - {{ t.artist }}</li>
+      {% endfor %}
+    </ol>
+  </div>
+</main>
+{% endblock %}

--- a/tests/test_gpt_jellyfin.py
+++ b/tests/test_gpt_jellyfin.py
@@ -134,3 +134,29 @@ def test_parse_gpt_line():
     assert describe_popularity(55) == "Moderately mainstream"
     assert describe_popularity(35) == "Niche appeal"
     assert describe_popularity(10) == "Obscure or local"
+
+
+def test_strip_number_prefix():
+    """strip_number_prefix should remove leading digits and punctuation."""
+    openai_stub = types.ModuleType("openai")
+
+    class Dummy:  # pylint: disable=too-few-public-methods
+        def __init__(self, **_kwargs):
+            return
+
+    openai_stub.OpenAI = Dummy
+    openai_stub.AsyncOpenAI = Dummy
+    openai_stub.OpenAIError = Exception
+    sys.modules["openai"] = openai_stub
+
+    cache_stub = types.ModuleType("utils.cache_manager")
+    cache_stub.prompt_cache = DummyCache()
+    cache_stub.lastfm_cache = DummyCache()
+    cache_stub.CACHE_TTLS = {"prompt": 1}
+    sys.modules["utils.cache_manager"] = cache_stub
+
+    gpt_mod = importlib.import_module("services.gpt")
+    strip_prefix = gpt_mod.strip_number_prefix
+
+    assert strip_prefix("1. Song - Artist") == "Song - Artist"
+    assert strip_prefix("10) Track - Name") == "Track - Name"


### PR DESCRIPTION
## Summary
- allow ChatGPT to suggest track order
- expose new `/suggest-order` endpoint
- add button on analysis page
- document new endpoint
- test helper for stripping numbered lines

## Testing
- `black .`
- `pylint core api services utils`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883de4f03e483329b8e15810da05d61