### PR TITLE
Fix long lines in GPT prompt

### DIFF
--- a/services/gpt.py
+++ b/services/gpt.py
@@ -296,10 +296,15 @@ async def fetch_order_suggestions(
     ]
     prompt = (
         "You are an expert DJ known for creating perfectly flowing playlists.\n"
-        f"Reorder the following {len(seed_lines)} tracks to maximize musical flow and emotional progression.\n"
-        "Consider transitions in tempo, energy, mood, genre, and style. Create a journey with natural rises and falls.\n"
-        "Start strong, build gradually, avoid abrupt changes, and end with a satisfying resolution.\n"
-        f"Return the new order using the exact format:\n\n1. Song - Artist\n2. Song - Artist\n...\n\nDo not add, remove, or comment on any tracks.\n\nTracks:\n"
+        f"Reorder the following {len(seed_lines)} tracks to maximize musical flow "
+        "and emotional progression.\n"
+        "Consider transitions in tempo, energy, mood, genre, and style. "
+        "Create a journey with natural rises and falls.\n"
+        "Start strong, build gradually, avoid abrupt changes, and end with a "
+        "satisfying resolution.\n"
+        "Return the new order using the exact format:\n\n"
+        "1. Song - Artist\n2. Song - Artist\n...\n\n"
+        "Do not add, remove, or comment on any tracks.\n\nTracks:\n"
         + "\n".join(seed_lines)
     )
 


### PR DESCRIPTION
## Summary
- shorten multi-line GPT prompt strings in `services/gpt.py`

## Testing
- `black .`
- `pylint core api services utils`
- `pytest` *(fails: ModuleNotFoundError for `core`, `config`, `utils`)*

------
https://chatgpt.com/codex/tasks/task_e_6883fa41804883328e1fc1084a6d83df