### PR TITLE
Make order modal scrollable and non-blocking

### DIFF
--- a/templates/analysis_result.html
+++ b/templates/analysis_result.html
@@ -50,13 +50,11 @@
 </div>
 
 <!-- Order Modal -->
-<div id="order-modal" class="hidden fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center">
-  <div class="bg-white dark:bg-gray-800 p-6 rounded shadow-lg max-w-md w-full">
-    <h2 class="text-xl font-semibold mb-4" id="order-modal-title"></h2>
-    <ol id="order-modal-list" class="list-decimal list-inside space-y-1 text-gray-800 dark:text-gray-200"></ol>
-    <div class="text-right mt-4">
-      <button id="order-modal-close" type="button" class="px-4 py-1 bg-blue-600 text-white rounded hover:bg-blue-700">Close</button>
-    </div>
+<div id="order-modal" class="hidden fixed bottom-4 right-4 z-50 bg-white dark:bg-gray-800 p-6 rounded shadow-lg max-w-md w-full" style="max-height: 80vh; overflow-y: auto;">
+  <h2 class="text-xl font-semibold mb-4" id="order-modal-title"></h2>
+  <ol id="order-modal-list" class="list-decimal list-inside space-y-1 text-gray-800 dark:text-gray-200"></ol>
+  <div class="text-right mt-4">
+    <button id="order-modal-close" type="button" class="px-4 py-1 bg-blue-600 text-white rounded hover:bg-blue-700">Close</button>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- display playlist order popup as fixed element instead of full-screen overlay
- allow long track lists to scroll

## Testing
- `black .`
- `pylint core api services utils`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883ff7eed588332a376d16adec42c34