### PR TITLE
Make playlist popup draggable

### DIFF
--- a/templates/analysis_result.html
+++ b/templates/analysis_result.html
@@ -50,8 +50,8 @@
 </div>
 
 <!-- Order Modal -->
-<div id="order-modal" class="hidden fixed bottom-4 right-4 z-50 bg-white dark:bg-gray-800 p-6 rounded shadow-lg max-w-md w-full" style="max-height: 80vh; overflow-y: auto;">
-  <h2 class="text-xl font-semibold mb-4" id="order-modal-title"></h2>
+<div id="order-modal" class="hidden fixed bottom-4 right-4 z-50 bg-white dark:bg-gray-800 p-6 rounded shadow-lg max-w-md w-full cursor-move" style="max-height: 80vh; overflow-y: auto;">
+  <h2 class="text-xl font-semibold mb-4 cursor-move" id="order-modal-title"></h2>
   <ol id="order-modal-list" class="list-decimal list-inside space-y-1 text-gray-800 dark:text-gray-200"></ol>
   <div class="text-right mt-4">
     <button id="order-modal-close" type="button" class="px-4 py-1 bg-blue-600 text-white rounded hover:bg-blue-700">Close</button>
@@ -338,6 +338,34 @@ document.addEventListener('DOMContentLoaded', () => {
   const orderTitle = document.getElementById('order-modal-title');
   const orderList = document.getElementById('order-modal-list');
   const orderClose = document.getElementById('order-modal-close');
+
+  // Draggable modal
+  if (orderModal) {
+    let drag = false;
+    let offsetX = 0;
+    let offsetY = 0;
+    const startDrag = e => {
+      drag = true;
+      const rect = orderModal.getBoundingClientRect();
+      offsetX = e.clientX - rect.left;
+      offsetY = e.clientY - rect.top;
+      orderModal.style.cursor = 'grabbing';
+      orderModal.style.bottom = 'auto';
+      orderModal.style.right = 'auto';
+    };
+    const onDrag = e => {
+      if (!drag) return;
+      orderModal.style.left = `${e.clientX - offsetX}px`;
+      orderModal.style.top = `${e.clientY - offsetY}px`;
+    };
+    const endDrag = () => {
+      drag = false;
+      orderModal.style.cursor = 'move';
+    };
+    orderModal.addEventListener('mousedown', startDrag);
+    document.addEventListener('mousemove', onDrag);
+    document.addEventListener('mouseup', endDrag);
+  }
 
   if (orderClose) {
     orderClose.addEventListener('click', () => orderModal.classList.add('hidden'));


### PR DESCRIPTION
## Summary
- make the order modal draggable
- let users keep interacting with the main page while moving it

## Testing
- `pylint core api services utils`
- `pytest` *(fails: ModuleNotFoundError: No module named 'utils')*

------
https://chatgpt.com/codex/tasks/task_e_688406a3bbb48332b764b18c09e37461