### PR TITLE
Add Jellyfin playlist removal action

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -593,6 +593,7 @@ async def analyze_selected_playlist(  # pylint: disable=too-many-locals
                 playlist_name = playlist.get("name")
                 break
 
+        playlist_id_to_use = playlist_id
     else:
         history = load_sorted_history(settings.jellyfin_user_id)
         entry = history[int(playlist_id)]
@@ -603,6 +604,7 @@ async def analyze_selected_playlist(  # pylint: disable=too-many-locals
             label_parts[0].strip() if len(label_parts) > 1 else entry.get("label")
         )
         playlist_name = f"{clean_label} Suggestions"
+        playlist_id_to_use = None
         start = perf_counter()
         enriched = []
         for t in tracks:
@@ -659,6 +661,7 @@ async def analyze_selected_playlist(  # pylint: disable=too-many-locals
             "gpt_summary": gpt_summary,
             "removal_suggestions": removal_suggestions,
             "playlist_name": playlist_name,
+            "playlist_id": playlist_id_to_use,
         },
     )
 
@@ -931,3 +934,24 @@ async def export_track_metadata(request: Request):  # pylint: disable=too-many-l
     return JSONResponse(
         {"message": f"Metadata for track '{title}' exported to Jellyfin."}
     )
+
+
+@router.post("/playlist/remove-item")
+async def remove_playlist_item(request: Request):
+    """Remove a track from a Jellyfin playlist."""
+    data = await request.json()
+    playlist_id = data.get("playlist_id")
+    item_id = data.get("item_id")
+    if not playlist_id or not item_id:
+        raise HTTPException(
+            status_code=400, detail="playlist_id and item_id are required"
+        )
+
+    success = await jellyfin.remove_item_from_playlist(playlist_id, item_id)
+    if not success:
+        raise HTTPException(
+            status_code=500,
+            detail="Failed to remove item from playlist",
+        )
+
+    return {"status": "success"}

--- a/core/playlist.py
+++ b/core/playlist.py
@@ -216,6 +216,7 @@ def normalize_track(raw: str | dict) -> Track:
             lyrics=lyrics,
             tempo=tempo_val,
             RunTimeTicks=raw.get("RunTimeTicks", 0),
+            Id=raw.get("Id"),
         )
 
     return Track(raw=str(raw), title="", artist="", album="", year="")

--- a/services/jellyfin.py
+++ b/services/jellyfin.py
@@ -452,6 +452,40 @@ async def update_item_metadata(item_id: str, full_item: dict) -> bool:
         return False
 
 
+async def remove_item_from_playlist(playlist_id: str, item_id: str) -> bool:
+    """Remove an item from a Jellyfin playlist."""
+    url = f"{settings.jellyfin_url.rstrip('/')}/Playlists/{playlist_id}/Items"
+    params = {
+        "Ids": item_id,
+        "UserId": settings.jellyfin_user_id,
+        "api_key": settings.jellyfin_api_key,
+    }
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.delete(
+                url,
+                params=params,
+                timeout=settings.http_timeout_short,
+            )
+        resp.raise_for_status()
+        record_success("jellyfin")
+        logger.info(
+            "✅ Removed item %s from playlist %s",
+            item_id,
+            playlist_id,
+        )
+        return True
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        record_failure("jellyfin")
+        logger.error(
+            "❌ Failed to remove item %s from playlist %s: %s",
+            item_id,
+            playlist_id,
+            exc,
+        )
+        return False
+
+
 def read_lrc_for_track(track_path: str) -> str | None:
     """
     Attempt to read an adjacent .lrc file for the given track path.

--- a/templates/analysis_result.html
+++ b/templates/analysis_result.html
@@ -72,7 +72,17 @@
       <ul class="list-disc pl-5 text-gray-200">
         {% for line in removal_suggestions.splitlines() %}
           {% if line %}
-            <li class="whitespace-pre-line">{{ line }}</li>
+            <li class="whitespace-pre-line flex justify-between items-center">
+              <span>{{ line }}</span>
+              {% if playlist_id %}
+                <button type="button"
+                        class="ml-2 text-sm text-red-500 underline remove-track-btn"
+                        data-line="{{ line }}"
+                        data-playlist-id="{{ playlist_id }}">
+                  Remove
+                </button>
+              {% endif %}
+            </li>
           {% endif %}
         {% endfor %}
       </ul>
@@ -653,6 +663,41 @@ document.querySelectorAll('.export-track-metadata').forEach(button => {
     }
   });
 });
+
+  // === Remove track buttons ===
+  document.querySelectorAll('.remove-track-btn').forEach(button => {
+    button.addEventListener('click', () => {
+      const line = button.getAttribute('data-line') || '';
+      const playlistId = button.getAttribute('data-playlist-id');
+      const cleaned = line.replace(/^\d+\.\s*/, '').trim();
+      const parts = cleaned.split(' - ');
+      const title = parts[0] || '';
+      const artist = parts[1] || '';
+      const track = (window.tracks || []).find(t => t.title === title && t.artist === artist);
+      const itemId = track && track.Id;
+      if (!itemId) {
+        alert('Track ID not found for removal.');
+        return;
+      }
+      if (!confirm(`Remove "${title}" by "${artist}" from this playlist?`)) {
+        return;
+      }
+      fetch('/playlist/remove-item', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ playlist_id: playlistId, item_id: itemId })
+      })
+      .then(resp => {
+        if (resp.ok) {
+          alert('Track removed from playlist');
+          button.disabled = true;
+        } else {
+          alert(`Failed to remove track (status ${resp.status})`);
+        }
+      })
+      .catch(() => alert('Network error while removing track'));
+    });
+  });
  
   // === Export to M3U ===
 


### PR DESCRIPTION
## Summary
- keep Jellyfin item ID when normalizing tracks
- add helper to remove a track from a Jellyfin playlist
- expose playlist_id to analysis results
- provide API route and UI button to delete suggested removals

## Testing
- `pip install -r requirements.txt`
- `pip install pylint black pytest`
- `black .`
- `pylint core api services utils`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_6884c04723988332a9d9ed94d4184963