### PR TITLE
Fix mypy error for Jellyfin track ID

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -17,6 +17,7 @@ class Track(BaseModel):
     tempo: Optional[int] = None
     RunTimeTicks: int = 0
     jellyfin_play_count: int = 0
+    Id: Optional[str] = None
 
     class Config:  # pylint: disable=too-few-public-methods
         """Pydantic configuration for ``Track`` model."""


### PR DESCRIPTION
## Summary
- define `Id` attribute on `Track` model so Jellyfin track IDs can be stored

## Testing
- `black .`
- `pylint core api services utils`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_6884c47c93f8833280d630bebe30b4ec