### PR TITLE
Fix missing docstring for Dummy stub

### DIFF
--- a/tests/test_gpt_jellyfin.py
+++ b/tests/test_gpt_jellyfin.py
@@ -170,6 +170,8 @@ def test_format_removal_suggestions():
     openai_stub = types.ModuleType("openai")
 
     class Dummy:  # pylint: disable=too-few-public-methods
+        """Simple OpenAI client stub used for import."""
+
         def __init__(self, **_kwargs):
             return
 


### PR DESCRIPTION
## Summary
- address `missing-class-docstring` lint error

## Testing
- `black .`
- `pylint core api services utils`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_6884c594ff4c833287616f69fb4888aa