### PR TITLE
Improve GPT line parsing for 'by' format

### DIFF
--- a/tests/test_gpt_jellyfin.py
+++ b/tests/test_gpt_jellyfin.py
@@ -129,6 +129,10 @@ def test_parse_gpt_line():
     assert title == "Song"
     assert artist == "Artist"
 
+    title, artist = parse_gpt_line("Another Song by Some Artist - Reason")
+    assert title == "Another Song"
+    assert artist == "Some Artist"
+
     assert describe_popularity(95) == "Global smash hit"
     assert describe_popularity(75) == "Mainstream favorite"
     assert describe_popularity(55) == "Moderately mainstream"


### PR DESCRIPTION
## Summary
- allow `parse_gpt_line` to handle lines formatted as `Song by Artist - Reason`
- extend `test_parse_gpt_line` with a case for the `by` variant

## Testing
- `black services/gpt.py tests/test_gpt_jellyfin.py`
- `pylint core api services utils`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_6884c6a1176c8332921e0eb73ae51102