### PR TITLE
Fix suggested removal display

### DIFF
--- a/templates/analysis_result.html
+++ b/templates/analysis_result.html
@@ -74,11 +74,11 @@
           {% if line %}
 
             <li class="whitespace-pre-line flex justify-between items-center">
-              <span>{{ line }}</span>
+              <span>{{ line | safe }}</span>
               {% if playlist_id %}
                 <button type="button"
                         class="ml-2 text-sm text-red-500 underline remove-track-btn"
-                        data-line="{{ line }}"
+                        data-line="{{ line | striptags }}"
                         data-playlist-id="{{ playlist_id }}">
                   Remove
                 </button>


### PR DESCRIPTION
## Summary
- show reasons on removal suggestions but keep them unbolded
- ensure HTML renders correctly in the removal suggestions list

## Testing
- `pylint core api services utils`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_6884c948e9508332a7492a7f5e3f98d8