### PR TITLE
Fix removing items from Jellyfin playlists

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -943,13 +943,13 @@ async def remove_playlist_item(request: Request):
     """Remove a track from a Jellyfin playlist."""
     data = await request.json()
     playlist_id = data.get("playlist_id")
-    item_id = data.get("item_id")
-    if not playlist_id or not item_id:
+    entry_id = data.get("item_id")
+    if not playlist_id or not entry_id:
         raise HTTPException(
             status_code=400, detail="playlist_id and item_id are required"
         )
 
-    success = await jellyfin.remove_item_from_playlist(playlist_id, item_id)
+    success = await jellyfin.remove_item_from_playlist(playlist_id, entry_id)
     if not success:
         raise HTTPException(
             status_code=500,

--- a/core/models.py
+++ b/core/models.py
@@ -18,6 +18,7 @@ class Track(BaseModel):
     RunTimeTicks: int = 0
     jellyfin_play_count: int = 0
     Id: Optional[str] = None
+    PlaylistItemId: Optional[str] = None
 
     class Config:  # pylint: disable=too-few-public-methods
         """Pydantic configuration for ``Track`` model."""

--- a/core/playlist.py
+++ b/core/playlist.py
@@ -217,6 +217,7 @@ def normalize_track(raw: str | dict) -> Track:
             tempo=tempo_val,
             RunTimeTicks=raw.get("RunTimeTicks", 0),
             Id=raw.get("Id"),
+            PlaylistItemId=raw.get("PlaylistItemId"),
         )
 
     return Track(raw=str(raw), title="", artist="", album="", year="")

--- a/services/jellyfin.py
+++ b/services/jellyfin.py
@@ -129,7 +129,7 @@ async def fetch_tracks_for_playlist_id(
         "UserId": settings.jellyfin_user_id,
         "Fields": (
             "Name,AlbumArtist,Artists,Album,ProductionYear,PremiereDate,"
-            "Genres,RunTimeTicks,Genres,UserData,HasLyrics,Path,Tags"
+            "Genres,RunTimeTicks,Genres,UserData,HasLyrics,Path,Tags,PlaylistItemId"
         ),
         "api_key": settings.jellyfin_api_key,
     }
@@ -452,11 +452,11 @@ async def update_item_metadata(item_id: str, full_item: dict) -> bool:
         return False
 
 
-async def remove_item_from_playlist(playlist_id: str, item_id: str) -> bool:
-    """Remove an item from a Jellyfin playlist."""
+async def remove_item_from_playlist(playlist_id: str, entry_id: str) -> bool:
+    """Remove a playlist entry from a Jellyfin playlist."""
     url = f"{settings.jellyfin_url.rstrip('/')}/Playlists/{playlist_id}/Items"
     params = {
-        "Ids": item_id,
+        "EntryIds": entry_id,
         "UserId": settings.jellyfin_user_id,
         "api_key": settings.jellyfin_api_key,
     }
@@ -470,16 +470,16 @@ async def remove_item_from_playlist(playlist_id: str, item_id: str) -> bool:
         resp.raise_for_status()
         record_success("jellyfin")
         logger.info(
-            "✅ Removed item %s from playlist %s",
-            item_id,
+            "✅ Removed entry %s from playlist %s",
+            entry_id,
             playlist_id,
         )
         return True
     except Exception as exc:  # pylint: disable=broad-exception-caught
         record_failure("jellyfin")
         logger.error(
-            "❌ Failed to remove item %s from playlist %s: %s",
-            item_id,
+            "❌ Failed to remove entry %s from playlist %s: %s",
+            entry_id,
             playlist_id,
             exc,
         )

--- a/templates/analysis_result.html
+++ b/templates/analysis_result.html
@@ -675,7 +675,7 @@ document.querySelectorAll('.export-track-metadata').forEach(button => {
       const title = parts[0] || '';
       const artist = parts[1] || '';
       const track = (window.tracks || []).find(t => t.title === title && t.artist === artist);
-      const itemId = track && track.Id;
+      const itemId = track && (track.PlaylistItemId || track.Id);
       if (!itemId) {
         alert('Track ID not found for removal.');
         return;

--- a/tests/test_remove_item.py
+++ b/tests/test_remove_item.py
@@ -1,0 +1,47 @@
+import asyncio
+import importlib
+import sys
+import types
+
+
+class DummyResp:
+    status_code = 204
+
+    def raise_for_status(self):
+        return None
+
+
+class DummyClient:
+    def __init__(self):
+        self.called = {}
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def delete(self, url, params=None, timeout=None):
+        self.called["url"] = url
+        self.called["params"] = params
+        self.called["timeout"] = timeout
+        return DummyResp()
+
+
+def test_remove_item_from_playlist(monkeypatch):
+    httpx_stub = types.ModuleType("httpx")
+    client = DummyClient()
+    httpx_stub.AsyncClient = lambda *a, **kw: client
+    sys.modules["httpx"] = httpx_stub
+    sys.modules.pop("services.jellyfin", None)
+    jellyfin = importlib.import_module("services.jellyfin")
+    jellyfin.settings.jellyfin_url = "http://jf"
+    jellyfin.settings.jellyfin_api_key = "k"
+    jellyfin.settings.jellyfin_user_id = "u"
+
+    result = asyncio.get_event_loop().run_until_complete(
+        jellyfin.remove_item_from_playlist("pl", "entry1")
+    )
+    assert result is True
+    assert client.called["url"] == "http://jf/Playlists/pl/Items"
+    assert client.called["params"]["EntryIds"] == "entry1"


### PR DESCRIPTION
## Summary
- include playlist item id when normalizing Jellyfin tracks
- request PlaylistItemId when fetching playlist items
- remove playlist entries with EntryIds
- update JS to use PlaylistItemId
- test removing an item from a playlist

## Testing
- `black .`
- `pylint core api services utils`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884cc74498483328ac44420769ebdb7