### PR TITLE
Fix playlist item removal

### DIFF
--- a/services/jellyfin.py
+++ b/services/jellyfin.py
@@ -456,7 +456,7 @@ async def remove_item_from_playlist(playlist_id: str, entry_id: str) -> bool:
     """Remove a playlist entry from a Jellyfin playlist."""
     url = f"{settings.jellyfin_url.rstrip('/')}/Playlists/{playlist_id}/Items"
     params = {
-        "EntryIds": entry_id,
+        "entryIds": entry_id,
         "UserId": settings.jellyfin_user_id,
         "api_key": settings.jellyfin_api_key,
     }

--- a/tests/test_remove_item.py
+++ b/tests/test_remove_item.py
@@ -44,4 +44,4 @@ def test_remove_item_from_playlist(monkeypatch):
     )
     assert result is True
     assert client.called["url"] == "http://jf/Playlists/pl/Items"
-    assert client.called["params"]["EntryIds"] == "entry1"
+    assert client.called["params"]["entryIds"] == "entry1"


### PR DESCRIPTION
## Summary
- send `entryIds` query parameter in the Jellyfin playlist removal helper
- update unit test for playlist item removal

## Testing
- `black .`
- `pylint core api services utils`
- `pytest` *(fails: ModuleNotFoundError)*
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884cfaa24808332af9afcb2b5e405a1