### PR TITLE
Fix lint warnings in remove_item test

### DIFF
--- a/tests/test_remove_item.py
+++ b/tests/test_remove_item.py
@@ -1,27 +1,39 @@
+"""Tests for ``remove_item_from_playlist`` in ``services.jellyfin``."""
+
 import asyncio
 import importlib
 import sys
 import types
 
+# pylint: disable=too-few-public-methods
+
 
 class DummyResp:
+    """Simple stand-in for ``httpx.Response``."""
+
     status_code = 204
 
     def raise_for_status(self):
+        """Pretend to validate the response status."""
         return None
 
 
 class DummyClient:
+    """Async ``httpx`` client stub capturing call parameters."""
+
     def __init__(self):
         self.called = {}
 
     async def __aenter__(self):
+        """Enter the asynchronous context."""
         return self
 
     async def __aexit__(self, exc_type, exc, tb):
+        """Exit without handling exceptions."""
         return False
 
     async def delete(self, url, params=None, timeout=None):
+        """Record the call parameters and return a ``DummyResp``."""
         self.called["url"] = url
         self.called["params"] = params
         self.called["timeout"] = timeout
@@ -29,10 +41,12 @@ class DummyClient:
 
 
 def test_remove_item_from_playlist(monkeypatch):
+    """Jellyfin deletion call should use the correct URL and params."""
+
     httpx_stub = types.ModuleType("httpx")
     client = DummyClient()
     httpx_stub.AsyncClient = lambda *a, **kw: client
-    sys.modules["httpx"] = httpx_stub
+    monkeypatch.setitem(sys.modules, "httpx", httpx_stub)
     sys.modules.pop("services.jellyfin", None)
     jellyfin = importlib.import_module("services.jellyfin")
     jellyfin.settings.jellyfin_url = "http://jf"


### PR DESCRIPTION
## Summary
- add documentation and pylint directives to `tests/test_remove_item.py`
- use pytest monkeypatch fixture to inject httpx stub

## Testing
- `black .`
- `pylint core api services utils tests/test_remove_item.py`
- `PYTHONPATH=$(pwd) pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884d1f8eea083328dda3c81f4be235f