### PR TITLE
Ensure removal suggestions include IDs

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -652,7 +652,7 @@ async def analyze_selected_playlist(  # pylint: disable=too-many-locals
     gpt_summary, removal_raw = await generate_playlist_analysis_summary(
         summary, enriched
     )
-    removal_suggestions = format_removal_suggestions(removal_raw)
+    removal_suggestions = format_removal_suggestions(removal_raw, parsed_enriched)
 
     return templates.TemplateResponse(
         "analysis_result.html",

--- a/templates/analysis_result.html
+++ b/templates/analysis_result.html
@@ -70,15 +70,14 @@
   <div class="p-4 transition-all duration-300 ease-in-out max-h-0 group-open:max-h-screen overflow-hidden">
     {% if removal_suggestions %}
       <ul class="list-disc pl-5 text-gray-200">
-        {% for line in removal_suggestions %}
-          {% if line %}
-
+        {% for item in removal_suggestions %}
+          {% if item.html %}
             <li class="whitespace-pre-line flex justify-between items-center">
-              <span>{{ line | safe }}</span>
-              {% if playlist_id %}
+              <span>{{ item.html | safe }}</span>
+              {% if playlist_id and item.item_id %}
                 <button type="button"
                         class="ml-2 text-sm text-red-500 underline remove-track-btn"
-                        data-line="{{ line | striptags }}"
+                        data-item-id="{{ item.item_id }}"
                         data-playlist-id="{{ playlist_id }}">
                   Remove
                 </button>
@@ -668,19 +667,13 @@ document.querySelectorAll('.export-track-metadata').forEach(button => {
   // === Remove track buttons ===
   document.querySelectorAll('.remove-track-btn').forEach(button => {
     button.addEventListener('click', () => {
-      const line = button.getAttribute('data-line') || '';
       const playlistId = button.getAttribute('data-playlist-id');
-      const cleaned = line.replace(/^\d+\.\s*/, '').trim();
-      const parts = cleaned.split(' - ');
-      const title = parts[0] || '';
-      const artist = parts[1] || '';
-      const track = (window.tracks || []).find(t => t.title === title && t.artist === artist);
-      const itemId = track && (track.PlaylistItemId || track.Id);
-      if (!itemId) {
-        alert('Track ID not found for removal.');
+      const itemId = button.getAttribute('data-item-id');
+      if (!playlistId || !itemId) {
+        alert('Missing playlist or track ID for removal.');
         return;
       }
-      if (!confirm(`Remove "${title}" by "${artist}" from this playlist?`)) {
+      if (!confirm('Remove this track from the playlist?')) {
         return;
       }
       fetch('/playlist/remove-item', {

--- a/tests/test_gpt_jellyfin.py
+++ b/tests/test_gpt_jellyfin.py
@@ -194,10 +194,20 @@ def test_format_removal_suggestions():
     format_lines = gpt_mod.format_removal_suggestions
 
     raw = "1. Foo - Bar - Reason\n2. Baz - Qux - Another\nThanks!"
-    result = format_lines(raw)
+    tracks = [
+        {"title": "Foo", "artist": "Bar", "PlaylistItemId": "1"},
+        {"title": "Baz", "artist": "Qux", "PlaylistItemId": "2"},
+    ]
+    result = format_lines(raw, tracks)
     assert result == [
-        "<strong>Foo</strong> - <strong>Bar</strong> - Reason",
-        "<strong>Baz</strong> - <strong>Qux</strong> - Another",
+        {
+            "html": "<strong>Foo</strong> - <strong>Bar</strong> - Reason",
+            "item_id": "1",
+        },
+        {
+            "html": "<strong>Baz</strong> - <strong>Qux</strong> - Another",
+            "item_id": "2",
+        },
     ]
 
 
@@ -226,7 +236,11 @@ def test_format_removal_suggestions_by_style():
     format_lines = gpt_mod.format_removal_suggestions
 
     raw = "1. Track One by Artist A - too fast"
-    result = format_lines(raw)
+    tracks = [{"title": "Track One", "artist": "Artist A", "PlaylistItemId": "x"}]
+    result = format_lines(raw, tracks)
     assert result == [
-        "<strong>Track One</strong> - <strong>Artist A</strong> - too fast",
+        {
+            "html": "<strong>Track One</strong> - <strong>Artist A</strong> - too fast",
+            "item_id": "x",
+        },
     ]


### PR DESCRIPTION
## Summary
- map suggested removals to playlist item IDs
- pass the IDs to templates for removal buttons
- simplify JS to use data-item-id
- update tests for new removal suggestion structure

## Testing
- `black .`
- `pylint core api services utils`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6884d424357083329f9ce3a88fc5eecc