### PR TITLE
Change nav active link color

### DIFF
--- a/templates/macros.html
+++ b/templates/macros.html
@@ -12,7 +12,7 @@
       {% set is_active = current.startswith(href) %}
     {% endif %}
       <a href="{{ href }}"
-         class="px-2 py-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700 {% if is_active %}bg-blue-600 text-white{% else %}text-gray-800 dark:text-gray-100{% endif %}">
+         class="px-2 py-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700 {% if is_active %}bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-100{% else %}text-gray-800 dark:text-gray-100{% endif %}">
         {{ label }}
       </a>
   {% endfor %}


### PR DESCRIPTION
## Summary
- use hover color instead of blue for active navigation item

## Testing
- `black .`
- `pylint core api services utils`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6884dd6cf35c8332b5dc085830524d20