### PR TITLE
Fix Jellyfin playlist removal

### DIFF
--- a/services/jellyfin.py
+++ b/services/jellyfin.py
@@ -456,10 +456,10 @@ async def remove_item_from_playlist(playlist_id: str, entry_id: str) -> bool:
     """Remove a playlist entry from a Jellyfin playlist."""
     url = f"{settings.jellyfin_url.rstrip('/')}/Playlists/{playlist_id}/Items"
     params = {
-        "entryIds": entry_id,
+        "EntryIds": entry_id,
         "UserId": settings.jellyfin_user_id,
-        "api_key": settings.jellyfin_api_key,
     }
+    headers = {"X-Emby-Token": settings.jellyfin_api_key}
     logger.info(
         "Removing entry %s from playlist %s",
         entry_id,
@@ -473,6 +473,7 @@ async def remove_item_from_playlist(playlist_id: str, entry_id: str) -> bool:
             resp = await client.delete(
                 url,
                 params=params,
+                headers=headers,
                 timeout=settings.http_timeout_short,
             )
             logger.debug(

--- a/tests/test_remove_item.py
+++ b/tests/test_remove_item.py
@@ -32,10 +32,11 @@ class DummyClient:
         """Exit without handling exceptions."""
         return False
 
-    async def delete(self, url, params=None, timeout=None):
+    async def delete(self, url, params=None, headers=None, timeout=None):
         """Record the call parameters and return a ``DummyResp``."""
         self.called["url"] = url
         self.called["params"] = params
+        self.called["headers"] = headers
         self.called["timeout"] = timeout
         return DummyResp()
 
@@ -58,4 +59,5 @@ def test_remove_item_from_playlist(monkeypatch):
     )
     assert result is True
     assert client.called["url"] == "http://jf/Playlists/pl/Items"
-    assert client.called["params"]["entryIds"] == "entry1"
+    assert client.called["params"]["EntryIds"] == "entry1"
+    assert client.called["headers"]["X-Emby-Token"] == "k"


### PR DESCRIPTION
## Summary
- send Jellyfin auth via `X-Emby-Token` header in playlist deletion
- use `EntryIds` parameter for deleting playlist entries
- update unit test

## Testing
- `pylint core api services utils`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688501efe65c8332b67c8439d7e67b22