### PR TITLE
Add verify-entry API route

### DIFF
--- a/Docs/api_reference.md
+++ b/Docs/api_reference.md
@@ -23,6 +23,7 @@ The table below summarises the main endpoints exposed by Playlist Pilot. All end
 | POST | `/settings` | Update settings |
 | POST | `/api/test/lastfm` | Verify Last.fm connectivity |
 | POST | `/api/test/jellyfin` | Verify Jellyfin connectivity |
+| POST | `/api/verify-entry` | Verify a playlist entry ID |
 | GET | `/health` | Simple health check |
 
 Return codes generally follow HTTP conventions: 200 for success, 4xx for invalid input and 5xx for unexpected errors.

--- a/api/routes.py
+++ b/api/routes.py
@@ -559,6 +559,33 @@ async def test_getsongbpm(request: Request):
         )
 
 
+@router.post("/api/verify-entry")
+async def verify_playlist_entry(request: Request):
+    """Confirm that a playlist contains the specified entry ID."""
+    data = await request.json()
+    playlist_id = data.get("playlist_id")
+    entry_id = data.get("entry_id")
+
+    if not playlist_id or not entry_id:
+        return JSONResponse(
+            {
+                "success": False,
+                "error": "playlist_id and entry_id are required",
+            },
+            status_code=400,
+        )
+
+    tracks = await fetch_tracks_for_playlist_id(playlist_id)
+    match = next((t for t in tracks if t.get("PlaylistItemId") == entry_id), None)
+
+    if match:
+        return JSONResponse({"success": True, "track": match})
+
+    return JSONResponse(
+        {"success": False, "error": "Entry not found in playlist"}, status_code=404
+    )
+
+
 @router.get("/analyze", response_class=HTMLResponse)
 async def show_analysis_page(request: Request):
     """Display the playlist analysis form."""


### PR DESCRIPTION
## Summary
- add `/api/verify-entry` to confirm a playlist entry ID
- document the new route in API reference

## Testing
- `black .`
- `pylint core api services utils`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68850ec211a88332b6d5017cbea72090