### PR TITLE
Refactor Jellyfin removal params

### DIFF
--- a/services/jellyfin.py
+++ b/services/jellyfin.py
@@ -455,18 +455,15 @@ async def update_item_metadata(item_id: str, full_item: dict) -> bool:
 async def remove_item_from_playlist(playlist_id: str, entry_id: str) -> bool:
     """Remove a playlist entry from a Jellyfin playlist."""
     url = f"{settings.jellyfin_url.rstrip('/')}/Playlists/{playlist_id}/Items"
-    headers = {
-        "X-Emby-Token": settings.jellyfin_api_key,
-        "Content-Type": "application/json",
-    }
-    payload = {"EntryIds": [entry_id]}
+    headers = {"X-Emby-Token": settings.jellyfin_api_key}
+    params = {"EntryIds": entry_id, "UserId": settings.jellyfin_user_id}
     logger.info(
         "Removing entry %s from playlist %s",
         entry_id,
         playlist_id,
     )
     logger.debug("[remove_item_from_playlist] URL: %s", url)
-    logger.debug("[remove_item_from_playlist] JSON payload: %s", payload)
+    logger.debug("[remove_item_from_playlist] Params: %s", params)
     logger.debug(
         "[remove_item_from_playlist] Headers: %s",
         {"X-Emby-Token": "***" if headers.get("X-Emby-Token") else None},
@@ -479,7 +476,7 @@ async def remove_item_from_playlist(playlist_id: str, entry_id: str) -> bool:
                 "DELETE",
                 url,
                 headers=headers,
-                json=payload,
+                params=params,
                 timeout=settings.http_timeout_short,
             )
             logger.debug(

--- a/tests/test_remove_item.py
+++ b/tests/test_remove_item.py
@@ -32,18 +32,18 @@ class DummyClient:
         """Exit without handling exceptions."""
         return False
 
-    async def request(self, method, url, headers=None, json=None, timeout=None):
+    async def request(self, method, url, headers=None, params=None, timeout=None):
         """Record the call parameters and return a ``DummyResp``."""
         self.called["method"] = method
         self.called["url"] = url
         self.called["headers"] = headers
-        self.called["json"] = json
+        self.called["params"] = params
         self.called["timeout"] = timeout
         return DummyResp()
 
 
 def test_remove_item_from_playlist(monkeypatch):
-    """Jellyfin deletion call should use the correct URL and JSON body."""
+    """Jellyfin deletion call should use the correct URL params."""
 
     httpx_stub = types.ModuleType("httpx")
     client = DummyClient()
@@ -61,6 +61,7 @@ def test_remove_item_from_playlist(monkeypatch):
     assert result is True
     assert client.called["method"] == "DELETE"
     assert client.called["url"] == "http://jf/Playlists/pl/Items"
-    assert client.called["json"]["EntryIds"] == ["entry1"]
+    assert client.called["params"]["EntryIds"] == "entry1"
+    assert client.called["params"]["UserId"] == "u"
     assert client.called["headers"]["X-Emby-Token"] == "k"
-    assert client.called["headers"]["Content-Type"] == "application/json"
+    assert "Content-Type" not in client.called["headers"]


### PR DESCRIPTION
## Summary
- update `remove_item_from_playlist` to use DELETE query parameters
- verify new behaviour in unit test

## Testing
- `black .`
- `pylint core api services utils`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885224a4f8083328de979c928d4c754