### PR TITLE
Refactor playlist item removal

### DIFF
--- a/tests/test_remove_item.py
+++ b/tests/test_remove_item.py
@@ -98,5 +98,6 @@ def test_remove_item_from_playlist(monkeypatch):
     post_call = factory.clients[1].calls[0]
     assert post_call["method"] == "POST"
     assert post_call["url"] == "http://jf/Playlists/pl/Items"
-    assert post_call["json"] == {"UserId": "u", "Ids": [], "Clear": True}
+    assert post_call["params"] == {"ids": "", "userId": "u"}
+    assert post_call["json"] is None
     assert post_call["headers"]["X-Emby-Token"] == "k"


### PR DESCRIPTION
## Summary
- update Jellyfin remove_item_from_playlist to send query params
- update remove_item test to check params instead of JSON

## Testing
- `pylint core api services utils`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_688530da232883328b6b1423074c0371