### PR TITLE
Fix album overwrite check bug

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -3,25 +3,6 @@
 This file documents outstanding bugs discovered during a code audit.
 Fixed issues have been moved to [FIXED_BUGS.md](FIXED_BUGS.md).
 
-## 46. Album overwrite check triggers unnecessarily
-`export_track_metadata` asks for confirmation even when the Jellyfin album field is blank.
-```
-album_to_use = existing_album
-if not skip_album and incoming_album and existing_album != incoming_album:
-    if force_album_overwrite:
-        album_to_use = incoming_album
-    else:
-        return JSONResponse(
-            {
-                "action": "confirm_overwrite_album",
-                "current_album": existing_album,
-                "suggested_album": incoming_album,
-            },
-            status_code=409,
-        )
-```
-【F:api/routes.py†L884-L897】
-
 ## 47. `read_m3u` fails on non‑UTF‑8 files
 The loader decodes using UTF‑8 without fallback, raising ``UnicodeDecodeError`` for other encodings.
 

--- a/FIXED_BUGS.md
+++ b/FIXED_BUGS.md
@@ -504,3 +504,28 @@ def normalize_genre(raw: str | None) -> str:
             reasons.append("genre")
 ```
 【F:core/analysis.py†L142-L150】
+
+## 46. Album overwrite check triggers unnecessarily
+*Fixed.* The exporter now overwrites the album automatically when Jellyfin has no existing album value, avoiding an unnecessary confirmation prompt.
+
+`export_track_metadata` asked for confirmation even when the Jellyfin album field was blank.
+
+```python
+    album_to_use = existing_album
+    if not skip_album and incoming_album:
+        if not existing_album:
+            album_to_use = incoming_album
+        elif existing_album != incoming_album:
+            if force_album_overwrite:
+                album_to_use = incoming_album
+            else:
+                return JSONResponse(
+                    {
+                        "action": "confirm_overwrite_album",
+                        "current_album": existing_album,
+                        "suggested_album": incoming_album,
+                    },
+                    status_code=409,
+                )
+```
+【F:api/routes.py†L937-L952】

--- a/api/routes.py
+++ b/api/routes.py
@@ -935,18 +935,21 @@ async def export_track_metadata(request: Request):  # pylint: disable=too-many-l
     merged_tags = list(set(existing_tags).union(filter(None, new_tags)))
 
     album_to_use = existing_album
-    if not skip_album and incoming_album and existing_album != incoming_album:
-        if force_album_overwrite:
+    if not skip_album and incoming_album:
+        if not existing_album:
             album_to_use = incoming_album
-        else:
-            return JSONResponse(
-                {
-                    "action": "confirm_overwrite_album",
-                    "current_album": existing_album,
-                    "suggested_album": incoming_album,
-                },
-                status_code=409,
-            )
+        elif existing_album != incoming_album:
+            if force_album_overwrite:
+                album_to_use = incoming_album
+            else:
+                return JSONResponse(
+                    {
+                        "action": "confirm_overwrite_album",
+                        "current_album": existing_album,
+                        "suggested_album": incoming_album,
+                    },
+                    status_code=409,
+                )
 
     # Apply updates to full item
     full_item["Genres"] = merged_genres


### PR DESCRIPTION
## Summary
- prevent confirmation when Jellyfin album field is blank
- move bug 46 from BUGS.md to FIXED_BUGS.md

## Testing
- `black .`
- `pylint core api services utils`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_6885ee135780833281cf0a0a61587d58