### PR TITLE
Fix read_m3u encoding fallback

### DIFF
--- a/core/m3u.py
+++ b/core/m3u.py
@@ -145,7 +145,11 @@ def read_m3u(file_path: Path) -> list[dict]:
     logger.debug("Reading M3U file: %s", file_path)
     tracks = []
 
-    lines = file_path.read_text(encoding="utf-8").splitlines()
+    try:
+        lines = file_path.read_text(encoding="utf-8").splitlines()
+    except UnicodeDecodeError:
+        logger.debug("UTF-8 decode failed for %s, trying Latin-1", file_path)
+        lines = file_path.read_text(encoding="latin-1").splitlines()
     for line in lines:
         line = line.strip()
         if not line or line.startswith("#"):

--- a/tests/test_m3u.py
+++ b/tests/test_m3u.py
@@ -37,6 +37,7 @@ from core.m3u import (
     infer_track_metadata_from_path,
     generate_proposed_path,
     _parse_title_artist,
+    read_m3u,
 )  # pylint: disable=wrong-import-position
 
 
@@ -228,3 +229,13 @@ def test_import_handles_non_utf8(monkeypatch, tmp_path):
     track = hist[0]["suggestions"][0]
     assert track["artist"] == "Artist"
     assert track["title"] == "Title"
+
+
+def test_read_m3u_handles_non_utf8(tmp_path):
+    """``read_m3u`` should fall back to Latin-1 when UTF-8 decoding fails."""
+    m3u_path = tmp_path / "playlist.m3u"
+    m3u_path.write_text("Caf\xe9 - Title", encoding="latin-1")
+
+    result = read_m3u(m3u_path)
+
+    assert result == [{"artist": "Caf\xe9", "title": "Title"}]


### PR DESCRIPTION
## Summary
- allow `read_m3u` to fall back to Latin‑1 when UTF‑8 fails
- test fallback parsing of non‑UTF8 playlists

## Testing
- `pip install -r requirements.txt`
- `pip install pylint black pytest`
- `black .`
- `pylint core api services utils`
- `PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_e_6887569c14988332ba10b604bfafae69