### PR TITLE
Fix Jinja2 template path

### DIFF
--- a/core/templates.py
+++ b/core/templates.py
@@ -1,8 +1,9 @@
 """FastAPI template configuration and custom Jinja filters."""
 
 from fastapi.templating import Jinja2Templates
+from core.constants import BASE_DIR
 
-templates = Jinja2Templates(directory="templates")
+templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
 
 
 def duration_human(seconds: int) -> str:


### PR DESCRIPTION
## Summary
- load template directory from `BASE_DIR`

## Testing
- `black .`
- `pylint core api services utils`
- `PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_e_6887599b20d88332bf2378531cbc3ae4