### PR TITLE
Fix lyrics_enabled default

### DIFF
--- a/api/forms.py
+++ b/api/forms.py
@@ -30,7 +30,7 @@ class SettingsForm(AppSettings):
         youtube_max_duration: int = Form(360),
         library_scan_limit: int = Form(1000),
         music_library_root: str = Form("Movies/Music"),
-        lyrics_enabled: bool = Form(False),
+        lyrics_enabled: bool = Form(True),
         lyrics_weight: float = Form(1.5),
         bpm_weight: float = Form(1.0),
         tags_weight: float = Form(0.7),

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -30,3 +30,15 @@ def test_as_form_invalid_getsongbpm_headers():
         SettingsForm.as_form(**{**defaults, "getsongbpm_headers": "{bad"})
     assert excinfo.value.status_code == 400
     assert "getsongbpm_headers" in excinfo.value.detail
+
+
+def test_as_form_lyrics_enabled_default():
+    """The lyrics_enabled field should default to ``True`` for missing input."""
+    import inspect
+    from fastapi.params import Form
+
+    sig = inspect.signature(SettingsForm.as_form)
+    param = sig.parameters["lyrics_enabled"]
+
+    assert isinstance(param.default, Form)
+    assert param.default.default is True


### PR DESCRIPTION
## Summary
- align `lyrics_enabled` default in `SettingsForm.as_form` with `AppSettings`
- verify checkbox default via new unit test

## Testing
- `pylint core api services utils`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68875b8de5788332a60ce74af6676c0b