### PR TITLE
Fix pylint import warning in tests

### DIFF
--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1,10 +1,12 @@
 """Unit tests for the :class:`SettingsForm` helper functions."""
 
-import json
 import inspect
+import json
+
 from fastapi import HTTPException
 from fastapi.params import Form
 import pytest
+
 from config import AppSettings
 from api.forms import SettingsForm
 


### PR DESCRIPTION
## Summary
- reorder imports in `tests/test_forms.py`

## Testing
- `black tests/test_forms.py`
- `pylint core api services utils tests/test_forms.py`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68875fae3bf88332af91f3fd8c27817a