### PR TITLE
Fix bug record for read_m3u encoding

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -3,10 +3,6 @@
 This file documents outstanding bugs discovered during a code audit.
 Fixed issues have been moved to [FIXED_BUGS.md](FIXED_BUGS.md).
 
-## 47. `read_m3u` fails on non‑UTF‑8 files
-The loader decodes using UTF‑8 without fallback, raising ``UnicodeDecodeError`` for other encodings.
-
-
 ## 38. Template directory bound to current working directory
 `Jinja2Templates` uses the relative path ``"templates"`` so running the app from another directory cannot locate the HTML files.
 

--- a/FIXED_BUGS.md
+++ b/FIXED_BUGS.md
@@ -529,3 +529,15 @@ def normalize_genre(raw: str | None) -> str:
                 )
 ```
 【F:api/routes.py†L937-L952】
+
+## 47. `read_m3u` fails on non‑UTF‑8 files
+*Fixed.* `read_m3u` now falls back to Latin‑1 when UTF‑8 decoding fails.
+
+```python
+    try:
+        lines = file_path.read_text(encoding="utf-8").splitlines()
+    except UnicodeDecodeError:
+        logger.debug("UTF-8 decode failed for %s, trying Latin-1", file_path)
+        lines = file_path.read_text(encoding="latin-1").splitlines()
+```
+【F:core/m3u.py†L148-L152】


### PR DESCRIPTION
## Summary
- remove bug 47 from BUGS.md
- log fix for bug 47 in FIXED_BUGS.md

## Testing
- `black .`
- `pylint core api services utils`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68888e8f10948332bf106eb1bbb80084