### PR TITLE
Fix templates path

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -3,9 +3,6 @@
 This file documents outstanding bugs discovered during a code audit.
 Fixed issues have been moved to [FIXED_BUGS.md](FIXED_BUGS.md).
 
-## 38. Template directory bound to current working directory
-`Jinja2Templates` uses the relative path ``"templates"`` so running the app from another directory cannot locate the HTML files.
-
 ## 45. `lyrics_enabled` default disabled in settings form
 `SettingsForm.as_form` uses ``Form(False)`` which overrides the true default in ``AppSettings`` when saving settings.
 ```

--- a/FIXED_BUGS.md
+++ b/FIXED_BUGS.md
@@ -558,3 +558,13 @@ def normalize_genre(raw: str | None) -> str:
                 ...
 ```
 【F:services/jellyfin.py†L44-L79】
+
+## 38. Template directory bound to current working directory
+*Fixed.* `core.templates` now computes an absolute directory path so the app can
+load HTML files correctly no matter the invocation location.
+
+```python
+TEMPLATES_DIR = (Path(__file__).resolve().parent.parent / "templates").resolve()
+templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
+```
+【F:core/templates.py†L4-L10】

--- a/core/templates.py
+++ b/core/templates.py
@@ -1,9 +1,13 @@
 """FastAPI template configuration and custom Jinja filters."""
 
-from fastapi.templating import Jinja2Templates
-from core.constants import BASE_DIR
+from pathlib import Path
 
-templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
+from fastapi.templating import Jinja2Templates
+
+# Use an absolute path so running the app from another working directory
+# still finds the HTML templates bundled with the package.
+TEMPLATES_DIR = (Path(__file__).resolve().parent.parent / "templates").resolve()
+templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
 
 
 def duration_human(seconds: int) -> str:


### PR DESCRIPTION
## Summary
- ensure Jinja templates path uses an absolute directory
- note fix in FIXED_BUGS and remove from BUGS

## Testing
- `black .`
- `pylint core api services utils`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_688895e65ffc8332b60e0436a58354f5