### PR TITLE
Fix: remove solved lyrics_enabled bug

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -3,13 +3,6 @@
 This file documents outstanding bugs discovered during a code audit.
 Fixed issues have been moved to [FIXED_BUGS.md](FIXED_BUGS.md).
 
-## 45. `lyrics_enabled` default disabled in settings form
-`SettingsForm.as_form` uses ``Form(False)`` which overrides the true default in ``AppSettings`` when saving settings.
-```
-lyrics_enabled: bool = Form(False)
-```
-【F:api/forms.py†L14-L36】
-
 ## 39. Library scan records tracks with missing metadata
 `get_full_audio_library` appends song strings even when ``Name`` or ``AlbumArtist`` are ``None`` resulting in entries like ``"None - None"``.
 ```

--- a/FIXED_BUGS.md
+++ b/FIXED_BUGS.md
@@ -568,3 +568,11 @@ TEMPLATES_DIR = (Path(__file__).resolve().parent.parent / "templates").resolve()
 templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
 ```
 【F:core/templates.py†L4-L10】
+
+## 45. `lyrics_enabled` default disabled in settings form
+*Fixed.* The settings form now initializes ``lyrics_enabled`` with ``True`` so the application's default is preserved when the checkbox is omitted.
+
+```python
+lyrics_enabled: bool = Form(True)
+```
+【F:api/forms.py†L30-L36】


### PR DESCRIPTION
## Summary
- move solved `lyrics_enabled` default issue to FIXED_BUGS

## Testing
- `black . --check`
- `pylint core api services utils`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888e66842088332891b050f9ab24042