### PR TITLE
Fix library scan metadata bug

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -3,18 +3,6 @@
 This file documents outstanding bugs discovered during a code audit.
 Fixed issues have been moved to [FIXED_BUGS.md](FIXED_BUGS.md).
 
-## 39. Library scan records tracks with missing metadata
-`get_full_audio_library` appends song strings even when ``Name`` or ``AlbumArtist`` are ``None`` resulting in entries like ``"None - None"``.
-```
-for item in chunk:
-    if isinstance(item, dict):
-        song = item.get("Name")
-        artist = item.get("AlbumArtist")
-        items.append(f"{song} - {artist}")
-```
-【F:core/playlist.py†L150-L155】
-
-
 ## 31. `strip_lrc_timecodes` removes bracketed lyrics
 The helper deletes all `[text]` sections, erasing annotations like `[Chorus]` rather than only timecodes.
 ```

--- a/FIXED_BUGS.md
+++ b/FIXED_BUGS.md
@@ -576,3 +576,16 @@ templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
 lyrics_enabled: bool = Form(True)
 ```
 【F:api/forms.py†L30-L36】
+
+## 39. Library scan records tracks with missing metadata
+*Fixed.* ``get_full_audio_library`` now ignores items missing ``Name`` or ``AlbumArtist`` to avoid entries like ``"None - None"``.
+
+```python
+for item in chunk:
+    if isinstance(item, dict):
+        song = item.get("Name")
+        artist = item.get("AlbumArtist")
+        if song and artist:
+            items.append(f"{song} - {artist}")
+```
+【F:core/playlist.py†L150-L158】

--- a/core/playlist.py
+++ b/core/playlist.py
@@ -152,7 +152,8 @@ async def get_full_audio_library(force_refresh: bool = False) -> list[str]:
             if isinstance(item, dict):
                 song = item.get("Name")
                 artist = item.get("AlbumArtist")
-                items.append(f"{song} - {artist}")
+                if song and artist:
+                    items.append(f"{song} - {artist}")
         if len(chunk) < limit:
             break
         start_index += limit


### PR DESCRIPTION
## Summary
- skip incomplete items when building the full audio library
- move resolved bug record from BUGS.md to FIXED_BUGS.md

## Testing
- `black .`
- `pylint core api services utils`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_6888eab7c970833293157f8fcad815c1