### PR TITLE
Fix duration_human filter

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -50,15 +50,6 @@ for tag in tags or []:
 ```
 【F:core/playlist.py†L626-L630】
 
-## 25. `duration_human` filter rejects numeric strings
-The Jinja filter only accepts integers and returns `?:??` for float or string durations.
-```
-def duration_human(seconds: int) -> str:
-    if not isinstance(seconds, int):
-        return "?:??"
-    return f"{seconds // 60}:{seconds % 60:02d}"
-```
-【F:core/templates.py†L8-L12】
 
 ## 28. Debug route returns coroutine object
 The `/test-lastfm-tags` route calls the async `get_lastfm_tags` without awaiting it, returning a coroutine instead of tags.

--- a/FIXED_BUGS.md
+++ b/FIXED_BUGS.md
@@ -589,3 +589,17 @@ for item in chunk:
             items.append(f"{song} - {artist}")
 ```
 【F:core/playlist.py†L150-L158】
+
+## 25. `duration_human` filter rejects numeric strings
+*Fixed.* The template filter now accepts numeric strings and floats by casting them before formatting.
+
+```python
+def duration_human(seconds: int | float | str) -> str:
+    """Return ``MM:SS`` style duration strings for template rendering."""
+    try:
+        seconds_int = int(float(seconds))
+    except (TypeError, ValueError):
+        return "?:??"
+    return f"{seconds_int // 60}:{seconds_int % 60:02d}"
+```
+【F:core/templates.py†L13-L19】

--- a/core/templates.py
+++ b/core/templates.py
@@ -10,11 +10,13 @@ TEMPLATES_DIR = (Path(__file__).resolve().parent.parent / "templates").resolve()
 templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
 
 
-def duration_human(seconds: int) -> str:
+def duration_human(seconds: int | float | str) -> str:
     """Return ``MM:SS`` style duration strings for template rendering."""
-    if not isinstance(seconds, int):
+    try:
+        seconds_int = int(float(seconds))
+    except (TypeError, ValueError):
         return "?:??"
-    return f"{seconds // 60}:{seconds % 60:02d}"
+    return f"{seconds_int // 60}:{seconds_int % 60:02d}"
 
 
 templates.env.filters["duration_human"] = duration_human

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,0 +1,21 @@
+from core.templates import duration_human
+
+
+def test_duration_human_int():
+    """Integer seconds should format as MM:SS."""
+    assert duration_human(125) == "2:05"
+
+
+def test_duration_human_numeric_string():
+    """Numeric strings should be accepted."""
+    assert duration_human("125") == "2:05"
+
+
+def test_duration_human_float():
+    """Float seconds should be cast to int."""
+    assert duration_human(125.7) == "2:05"
+
+
+def test_duration_human_invalid():
+    """Non-numeric input should return placeholder."""
+    assert duration_human("foo") == "?:??"


### PR DESCRIPTION
## Summary
- accept numeric strings and floats in `duration_human`
- add unit tests for filter
- document fix in BUGS and FIXED_BUGS

## Testing
- `black .`
- `pylint core api services utils`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_6888f38f7cb48332b00f3a8b46049815