### PR TITLE
Fix strip_lrc_timecodes removing bracketed lyrics

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -3,14 +3,6 @@
 This file documents outstanding bugs discovered during a code audit.
 Fixed issues have been moved to [FIXED_BUGS.md](FIXED_BUGS.md).
 
-## 31. `strip_lrc_timecodes` removes bracketed lyrics
-The helper deletes all `[text]` sections, erasing annotations like `[Chorus]` rather than only timecodes.
-```
-return re.sub(r"\[.*?\]", "", lrc_text).strip()
-```
-【F:services/jellyfin.py†L484-L494】
-
-
 ## 34. OpenAI test route blocks the event loop
 `test_openai` performs a synchronous API call inside an async route without ``await`` or ``to_thread``.
 ```

--- a/FIXED_BUGS.md
+++ b/FIXED_BUGS.md
@@ -603,3 +603,12 @@ def duration_human(seconds: int | float | str) -> str:
     return f"{seconds_int // 60}:{seconds_int % 60:02d}"
 ```
 【F:core/templates.py†L13-L19】
+
+## 31. `strip_lrc_timecodes` removes bracketed lyrics
+*Fixed.* Timecodes are now matched with a specific regex so annotations like `[Chorus]` remain intact.
+
+```python
+    timecode_pattern = r"\[(?:\d{1,2}:)?\d{1,2}:\d{2}(?:\.\d{1,2})?\]"
+    return re.sub(timecode_pattern, "", lrc_text).strip()
+```
+【F:services/jellyfin.py†L488-L498】

--- a/services/jellyfin.py
+++ b/services/jellyfin.py
@@ -486,8 +486,7 @@ def read_lrc_for_track(track_path: str) -> str | None:
 
 
 def strip_lrc_timecodes(lrc_text: str) -> str:
-    """
-    Remove [mm:ss.xx] style timecodes from LRC file contents.
+    """Remove `[mm:ss.xx]` style timecodes from LRC file contents.
 
     Args:
         lrc_text (str): Raw LRC contents.
@@ -495,4 +494,5 @@ def strip_lrc_timecodes(lrc_text: str) -> str:
     Returns:
         str: Plain lyrics text without timecodes.
     """
-    return re.sub(r"\[.*?\]", "", lrc_text).strip()
+    timecode_pattern = r"\[(?:\d{1,2}:)?\d{1,2}:\d{2}(?:\.\d{1,2})?\]"
+    return re.sub(timecode_pattern, "", lrc_text).strip()


### PR DESCRIPTION
## Summary
- tighten regex in `strip_lrc_timecodes`
- remove bug 31 from BUGS.md and document fix in FIXED_BUGS.md

## Testing
- `black .`
- `pylint core api services utils`
- `PYTHONPATH=$(pwd) pytest`

------
https://chatgpt.com/codex/tasks/task_e_6888f64809b8833283a720e059ddfcb5