### PR TITLE
Fix OpenAI test route blocking

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -3,15 +3,6 @@
 This file documents outstanding bugs discovered during a code audit.
 Fixed issues have been moved to [FIXED_BUGS.md](FIXED_BUGS.md).
 
-## 34. OpenAI test route blocks the event loop
-`test_openai` performs a synchronous API call inside an async route without ``await`` or ``to_thread``.
-```
-    client = openai.OpenAI(api_key=key)
-    models = client.models.list()
-    valid = any(m.id.startswith("gpt") for m in models.data)
-```
-【F:api/routes.py†L491-L499】
-
 ## 51. GPT prompt cache ignores model choice
 `cached_chat_completion` builds its cache key from only the prompt and temperature, so switching models may return stale text.
 ```

--- a/FIXED_BUGS.md
+++ b/FIXED_BUGS.md
@@ -612,3 +612,14 @@ def duration_human(seconds: int | float | str) -> str:
     return re.sub(timecode_pattern, "", lrc_text).strip()
 ```
 【F:services/jellyfin.py†L488-L498】
+
+## 34. OpenAI test route blocks the event loop
+*Fixed.* `test_openai` now performs the model listing in a thread to avoid blocking.
+```python
+    def _list_models():
+        client = openai.OpenAI(api_key=key)
+        return client.models.list()
+
+    models = await asyncio.to_thread(_list_models)
+```
+【F:api/routes.py†L500-L509】

--- a/api/routes.py
+++ b/api/routes.py
@@ -502,8 +502,12 @@ async def test_openai(request: Request):
     data = await request.json()
     key = data.get("key")
     try:
-        client = openai.OpenAI(api_key=key)
-        models = client.models.list()
+
+        def _list_models():
+            client = openai.OpenAI(api_key=key)
+            return client.models.list()
+
+        models = await asyncio.to_thread(_list_models)
         valid = any(m.id.startswith("gpt") for m in models.data)
         return JSONResponse({"success": valid})
     except openai.OpenAIError as exc:


### PR DESCRIPTION
## Summary
- make `/api/test/openai` run the synchronous model list in a thread
- update bug documentation

## Testing
- `black .`
- `pylint core api services utils`
- `PYTHONPATH=$PWD pytest`

------
https://chatgpt.com/codex/tasks/task_e_6888f7d67270833286676a1e7ef3e572