### PR TITLE
Fix GPT cache key

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -3,14 +3,6 @@
 This file documents outstanding bugs discovered during a code audit.
 Fixed issues have been moved to [FIXED_BUGS.md](FIXED_BUGS.md).
 
-## 51. GPT prompt cache ignores model choice
-`cached_chat_completion` builds its cache key from only the prompt and temperature, so switching models may return stale text.
-```
-key = prompt_fingerprint(f"{prompt}|temperature={temperature}")
-content = prompt_cache.get(key)
-```
-【F:services/gpt.py†L139-L167】
-
 ## 52. `get_playlist_id_by_name` fetches all playlists
 The helper retrieves the full playlist list and scans it every call, which is inefficient on large libraries.
 ```

--- a/FIXED_BUGS.md
+++ b/FIXED_BUGS.md
@@ -623,3 +623,12 @@ def duration_human(seconds: int | float | str) -> str:
     models = await asyncio.to_thread(_list_models)
 ```
 【F:api/routes.py†L500-L509】
+
+## 51. GPT prompt cache ignores model choice
+*Fixed.* The cache key now incorporates the selected model so prompts for different models don't collide.
+```python
+    key = prompt_fingerprint(
+        f"{prompt}|temperature={temperature}|model={settings.model}"
+    )
+```
+【F:services/gpt.py†L137-L151】

--- a/services/gpt.py
+++ b/services/gpt.py
@@ -135,8 +135,8 @@ def cached_chat_completion_sync(prompt: str, temperature: float = 0.7) -> str:
         str: GPT's raw response content.
     """
     key = prompt_fingerprint(
-        f"{prompt}|temperature={temperature}"
-    )  # Ensure cache keys differentiate by temperature
+        f"{prompt}|temperature={temperature}|model={settings.model}"
+    )  # Ensure cache keys differentiate by model and temperature
     content = prompt_cache.get(key)
     if content is not None:
         logger.info("GPT cache hit: %s", key)
@@ -158,7 +158,9 @@ def cached_chat_completion_sync(prompt: str, temperature: float = 0.7) -> str:
 
 async def cached_chat_completion(prompt: str, temperature: float = 0.7) -> str:
     """Asynchronous variant of cached_chat_completion."""
-    key = prompt_fingerprint(f"{prompt}|temperature={temperature}")
+    key = prompt_fingerprint(
+        f"{prompt}|temperature={temperature}|model={settings.model}"
+    )
     content = prompt_cache.get(key)
     if content is not None:
         logger.info("GPT cache hit: %s", key)


### PR DESCRIPTION
## Summary
- include the model name in GPT cache keys
- remove corresponding issue from BUGS
- document fix in FIXED_BUGS

## Testing
- `black .`
- `pylint core api services utils`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_6888fcf01dc88332a7d9268a1a7858dd