### PR TITLE
Fix case-insensitive tag extraction

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -4,15 +4,6 @@ This file documents outstanding bugs discovered during a code audit.
 Fixed issues have been moved to [FIXED_BUGS.md](FIXED_BUGS.md).
 
 
-## 33. Tag extraction is case-sensitive
-`extract_tag_value` only matches lowercase prefixes and misses tags like `Tempo:120`.
-```
-for tag in tags or []:
-    if tag.startswith(f"{prefix}:"):
-        return tag.split(":", 1)[1]
-```
-【F:core/playlist.py†L626-L630】
-
 
 ## 28. Debug route returns coroutine object
 The `/test-lastfm-tags` route calls the async `get_lastfm_tags` without awaiting it, returning a coroutine instead of tags.

--- a/FIXED_BUGS.md
+++ b/FIXED_BUGS.md
@@ -477,6 +477,16 @@ norm_lfm = normalize_popularity_log(
 ```
 【F:utils/helpers.py†L49-L67】
 
+## 33. Tag extraction is case-sensitive
+*Fixed.* `extract_tag_value` now matches prefixes in a case-insensitive manner.
+```python
+    prefix_lower = prefix.lower()
+    for tag in tags or []:
+        if tag.lower().startswith(f"{prefix_lower}:"):
+            return tag.split(":", 1)[1]
+```
+【F:core/playlist.py†L638-L642】
+
 ## 35. `normalize_genre` crashes on ``None`` input
 *Fixed.* The helper now returns an empty string when passed ``None`` or another falsy value.
 

--- a/TODO.md
+++ b/TODO.md
@@ -13,7 +13,7 @@ This file outlines upcoming tasks based on the current roadmap and list of outst
 - [ ] **34. OpenAI test route blocks the event loop** – make the request asynchronous.
 - [ ] **51. GPT prompt cache ignores model choice** – include the model name in the cache key.
 - [ ] **52. `get_playlist_id_by_name` fetches all playlists** – query Jellyfin for a single playlist instead.
-- [ ] **33. Tag extraction is case-sensitive** – support capitalized prefixes.
+- [X] **33. Tag extraction is case-sensitive** – support capitalized prefixes.
 - [ ] **25. `duration_human` filter rejects numeric strings** – accept numeric strings or floats.
 - [ ] **28. Debug route returns coroutine object** – await `get_lastfm_tags` in the debug route.
 - [ ] **48. `parse_gpt_line` hides malformed suggestions** – raise an error or log invalid lines.

--- a/core/playlist.py
+++ b/core/playlist.py
@@ -635,8 +635,9 @@ def extract_tag_value(tags: list[str], prefix: str) -> str | None:
     Returns:
         str or None: Value part if found, else None.
     """
+    prefix_lower = prefix.lower()
     for tag in tags or []:
-        if tag.startswith(f"{prefix}:"):
+        if tag.lower().startswith(f"{prefix_lower}:"):
             return tag.split(":", 1)[1]
     return None
 

--- a/tests/test_playlist_helpers.py
+++ b/tests/test_playlist_helpers.py
@@ -100,9 +100,10 @@ def test_estimate_tempo_basic():
 
 def test_extract_tag_value():
     """`extract_tag_value` should pull the value for a named tag."""
-    tags = ["tempo:120", "mood:happy"]
+    tags = ["tempo:120", "mood:happy", "Tempo:130"]
     assert extract_tag_value(tags, "tempo") == "120"
     assert extract_tag_value(tags, "missing") is None
+    assert extract_tag_value(["Tempo:120"], "tempo") == "120"
 
 
 def test_load_sorted_history(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- make `extract_tag_value` handle tag prefixes case-insensitively
- test case-insensitive tag extraction
- move bug 33 from BUGS to FIXED_BUGS
- update TODO

## Testing
- `pylint core api services utils`
- `PYTHONPATH=$PWD pytest`

------
https://chatgpt.com/codex/tasks/task_e_6889f55b3858833296bfc34000aad6c7