### PR TITLE
Fix Last.fm debug route

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -3,19 +3,6 @@
 This file documents outstanding bugs discovered during a code audit.
 Fixed issues have been moved to [FIXED_BUGS.md](FIXED_BUGS.md).
 
-
-
-## 28. Debug route returns coroutine object
-The `/test-lastfm-tags` route calls the async `get_lastfm_tags` without awaiting it, returning a coroutine instead of tags.
-```
-@router.get("/test-lastfm-tags")
-def debug_lastfm_tags(title: str, artist: str):
-    """Return tags for a given track from Last.fm for debugging."""
-    tags = get_lastfm_tags(title, artist)
-    return {"tags": tags}
-```
-【F:api/routes.py†L659-L663】
-
 ## 48. `parse_gpt_line` hides malformed suggestions
 Invalid lines return empty strings instead of raising an error.
 ```

--- a/FIXED_BUGS.md
+++ b/FIXED_BUGS.md
@@ -655,3 +655,14 @@ def duration_human(seconds: int | float | str) -> str:
     )
 ```
 【F:core/playlist.py†L82-L101】
+
+## 28. Debug route returns coroutine object
+*Fixed.* The `/test-lastfm-tags` endpoint is now asynchronous and awaits ``get_lastfm_tags``.
+```python
+@router.get("/test-lastfm-tags")
+async def debug_lastfm_tags(title: str, artist: str):
+    """Return tags for a given track from Last.fm for debugging."""
+    tags = await get_lastfm_tags(title, artist)
+    return {"tags": tags}
+```
+【F:api/routes.py†L702-L706】

--- a/api/routes.py
+++ b/api/routes.py
@@ -700,9 +700,9 @@ async def analyze_selected_playlist(  # pylint: disable=too-many-locals
 
 
 @router.get("/test-lastfm-tags")
-def debug_lastfm_tags(title: str, artist: str):
+async def debug_lastfm_tags(title: str, artist: str):
     """Return tags for a given track from Last.fm for debugging."""
-    tags = get_lastfm_tags(title, artist)
+    tags = await get_lastfm_tags(title, artist)
     return {"tags": tags}
 
 


### PR DESCRIPTION
## Summary
- await `get_lastfm_tags` in `/test-lastfm-tags`
- move bug 28 to `FIXED_BUGS.md`

## Testing
- `black .`
- `pylint core api services utils`
- `pytest` *(fails: ModuleNotFoundError: No module named 'core')*

------
https://chatgpt.com/codex/tasks/task_e_6889f778c8288332b0a2f8bd3a6e71db