### PR TITLE
Improve lastfm normalize regex

### DIFF
--- a/services/lastfm.py
+++ b/services/lastfm.py
@@ -19,8 +19,12 @@ from utils.integration_watchdog import record_failure, record_success
 logger = logging.getLogger("playlist-pilot")
 
 # Precompile regex patterns for efficiency and to avoid backtracking
-_paren_re = re.compile(r"\s*\([^)]*\)")
+# Avoid leading whitespace in the parenthetical pattern to prevent
+# catastrophic backtracking on long inputs consisting of spaces or
+# parentheses.
+_paren_re = re.compile(r"\([^)]*\)")
 _punct_re = re.compile(r"[^a-z0-9 ]")
+_space_re = re.compile(r"\s+")
 
 
 def normalize(text: str) -> str:
@@ -28,6 +32,7 @@ def normalize(text: str) -> str:
     text = text.lower()
     text = _paren_re.sub("", text)  # Remove content in parentheses
     text = _punct_re.sub("", text)  # Remove punctuation
+    text = _space_re.sub(" ", text)  # Collapse whitespace
     return text.strip()
 
 

--- a/tests/test_lastfm.py
+++ b/tests/test_lastfm.py
@@ -35,3 +35,17 @@ def test_normalize_multiple_parens(monkeypatch):
     normalize = _load_normalize(monkeypatch)
     text = "(((Example)))"
     assert normalize(text) == ""
+
+
+def test_normalize_long_spaces(monkeypatch):
+    """Many spaces should not impact performance or output."""
+    normalize = _load_normalize(monkeypatch)
+    text = " " * 500 + "Example"
+    assert normalize(text) == "example"
+
+
+def test_normalize_long_open_parens(monkeypatch):
+    """Strings starting with numerous '(' characters are handled."""
+    normalize = _load_normalize(monkeypatch)
+    text = "(" * 500 + "Example"
+    assert normalize(text) == "example"


### PR DESCRIPTION
## Summary
- optimize regex used for parenthesis stripping in `services.lastfm`
- collapse whitespace when normalizing text
- add tests for long inputs of spaces and parentheses

## Testing
- `pylint core api services utils`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889f99296dc8332ada3deccf7401da7