### PR TITLE
Fix search query dash splitting

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -4,14 +4,6 @@ This file documents outstanding bugs discovered during a code audit.
 Fixed issues have been moved to [FIXED_BUGS.md](FIXED_BUGS.md).
 
 
-## 49. `build_search_query` splits on every dash
-Hyphens inside artist or title confuse the query generator.
-```
-parts = [part.strip() for part in line.split("-")]
-return f"{parts[0]} {parts[1]}" if len(parts) >= 2 else line.strip()
-```
-【F:utils/text_utils.py†L39-L42】
-
 ## 50. `parse_track_text` drops data after second dash
 Extra segments beyond ``Artist - Title`` are ignored.
 ```

--- a/FIXED_BUGS.md
+++ b/FIXED_BUGS.md
@@ -679,3 +679,12 @@ async def debug_lastfm_tags(title: str, artist: str):
     raise ValueError(f"Could not parse suggestion line: {line}")
 ```
 【F:services/gpt.py†L183-L211】
+
+## 49. `build_search_query` splits on every dash
+*Fixed.* ``build_search_query`` now splits only once so dashes inside titles are preserved.
+```python
+def build_search_query(line: str) -> str:
+    parts = [part.strip() for part in line.split("-", 1)]
+    return f"{parts[0]} {parts[1]}" if len(parts) >= 2 else line.strip()
+```
+【F:utils/text_utils.py†L39-L42】

--- a/tests/test_text_utils.py
+++ b/tests/test_text_utils.py
@@ -24,5 +24,5 @@ def test_clean_and_build_query():
     assert tu.clean(" Hello!!! ") == "hello"
     assert tu.clean("MiXeD Case") == "mixed case"
 
-    assert tu.build_search_query("Song - Artist - Extra") == "Song Artist"
+    assert tu.build_search_query("Song - Artist - Extra") == "Song Artist - Extra"
     assert tu.build_search_query("Solo") == "Solo"

--- a/utils/text_utils.py
+++ b/utils/text_utils.py
@@ -38,5 +38,5 @@ def clean(text: str) -> str:
 
 def build_search_query(line: str) -> str:
     """Extract a basic search query from a track label."""
-    parts = [part.strip() for part in line.split("-")]
+    parts = [part.strip() for part in line.split("-", 1)]
     return f"{parts[0]} {parts[1]}" if len(parts) >= 2 else line.strip()


### PR DESCRIPTION
## Summary
- prevent build_search_query from splitting on all dashes
- adjust text utils test
- document fix in FIXED_BUGS
- remove entry from BUGS

## Testing
- `pylint core api services utils`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_688b3693e98083329e33e2c1b989d3eb