### PR TITLE
Fix parse_track_text bug

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -4,17 +4,6 @@ This file documents outstanding bugs discovered during a code audit.
 Fixed issues have been moved to [FIXED_BUGS.md](FIXED_BUGS.md).
 
 
-## 50. `parse_track_text` drops data after second dash
-Extra segments beyond ``Artist - Title`` are ignored.
-```
-parts = text.split(" - ")
-if len(parts) >= 2:
-    artist, title = parts[0].strip(), parts[1].strip()
-else:
-    artist, title = "Unknown", text.strip()
-```
-【F:core/m3u.py†L68-L74】
-
 ## 53. Filename metadata inference misreads complex names
 `infer_track_metadata_from_path` only keeps the last two dash-separated parts, so ``Artist - Title - Live.mp3`` records ``Title - Live`` as the title.
 ```

--- a/FIXED_BUGS.md
+++ b/FIXED_BUGS.md
@@ -688,3 +688,16 @@ def build_search_query(line: str) -> str:
     return f"{parts[0]} {parts[1]}" if len(parts) >= 2 else line.strip()
 ```
 【F:utils/text_utils.py†L39-L42】
+
+## 50. `parse_track_text` drops data after second dash
+*Fixed.* The parser now splits only once so additional segments remain part of the title.
+```python
+def parse_track_text(text: str) -> tuple[str, str]:
+    parts = text.split(" - ", 1)
+    if len(parts) >= 2:
+        artist, title = parts[0].strip(), parts[1].strip()
+    else:
+        artist, title = "Unknown", text.strip()
+    return artist, title
+```
+【F:core/m3u.py†L67-L76】

--- a/core/m3u.py
+++ b/core/m3u.py
@@ -66,7 +66,7 @@ def generate_proposed_path(artist: str, album: str, title: str) -> str:
 
 def parse_track_text(text: str) -> tuple[str, str]:
     """Split a track label into artist and title parts."""
-    parts = text.split(" - ")
+    parts = text.split(" - ", 1)
     if len(parts) >= 2:
         artist, title = parts[0].strip(), parts[1].strip()
     else:

--- a/tests/test_m3u.py
+++ b/tests/test_m3u.py
@@ -59,7 +59,7 @@ def test_parse_track_text_extra_parts():
     """Handle extra segments after artist and title."""
     artist, title = parse_track_text("Metallica - One - Live")
     assert artist == "Metallica"
-    assert title == "One"
+    assert title == "One - Live"
 
 
 def test_parse_title_artist_full_line():


### PR DESCRIPTION
## Summary
- fix `parse_track_text` to keep all text after the first dash
- update associated test
- move bug 50 to FIXED_BUGS.md

## Testing
- `black .`
- `pylint core api services utils`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b3adf73148332a6b2b5db214198ce