### PR TITLE
Fix metadata inference for complex filenames

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -4,16 +4,6 @@ This file documents outstanding bugs discovered during a code audit.
 Fixed issues have been moved to [FIXED_BUGS.md](FIXED_BUGS.md).
 
 
-## 53. Filename metadata inference misreads complex names
-`infer_track_metadata_from_path` only keeps the last two dash-separated parts, so ``Artist - Title - Live.mp3`` records ``Title - Live`` as the title.
-```
-segments = clean_title.split(" - ")
-if len(segments) >= 2:
-    artist = segments[-2].strip()
-    title = segments[-1].strip()
-```
-【F:core/m3u.py†L161-L177】
-
 ## 54. Last.fm normalization strips accented characters
 `normalize` removes all non-ASCII characters so artists like "Beyoncé" are cached without the accent, causing mismatches.
 ```

--- a/FIXED_BUGS.md
+++ b/FIXED_BUGS.md
@@ -701,3 +701,15 @@ def parse_track_text(text: str) -> tuple[str, str]:
     return artist, title
 ```
 【F:core/m3u.py†L67-L76】
+
+## 53. Filename metadata inference misreads complex names
+*Fixed.* `infer_track_metadata_from_path` now splits only once, preserving extra dashes in titles.
+```python
+    clean_title = re.sub(r"^\d+\s*[-_.]\s*", "", filename).strip()
+    if " - " in clean_title:
+        artist, title = parse_track_text(clean_title)
+    else:
+        title = clean_title
+        artist = parts[-3] if len(parts) >= 3 else "Unknown Artist"
+```
+【F:core/m3u.py†L165-L175】

--- a/core/m3u.py
+++ b/core/m3u.py
@@ -168,13 +168,7 @@ def infer_track_metadata_from_path(path: str) -> dict:
     filename = parts[-1].rsplit(".", 1)[0]
     clean_title = re.sub(r"^\d+\s*[-_.]\s*", "", filename).strip()
     if " - " in clean_title:
-        segments = clean_title.split(" - ")
-        if len(segments) >= 2:
-            artist = segments[-2].strip()
-            title = segments[-1].strip()
-        else:
-            title = segments[-1].strip()
-            artist = parts[-3] if len(parts) >= 3 else "Unknown Artist"
+        artist, title = parse_track_text(clean_title)
     else:
         title = clean_title
         artist = parts[-3] if len(parts) >= 3 else "Unknown Artist"

--- a/tests/test_m3u.py
+++ b/tests/test_m3u.py
@@ -95,6 +95,14 @@ def test_infer_metadata_windows_path():
     assert meta == {"title": "One", "artist": "Metallica"}
 
 
+def test_infer_metadata_multiple_dashes():
+    """Handle filenames with additional dashes."""
+    meta = infer_track_metadata_from_path(
+        "Music/Metallica/Justice/Metallica - One - Live.mp3"
+    )
+    assert meta == {"title": "One - Live", "artist": "Metallica"}
+
+
 def test_generate_proposed_path_sanitizes(monkeypatch, tmp_path):
     """Path components are sanitized to prevent traversal and invalid characters."""
     monkeypatch.setattr(settings, "music_library_root", str(tmp_path), raising=False)


### PR DESCRIPTION
## Summary
- fix `infer_track_metadata_from_path` so filenames with multiple dashes keep the extra text
- add regression test
- document fix in `FIXED_BUGS.md` and remove bug from `BUGS.md`

## Testing
- `black .`
- `pylint core api services utils`
- `PYTHONPATH=$PWD pytest`

------
https://chatgpt.com/codex/tasks/task_e_688b3e0b9490833288b1caf2dacc0b52