### PR TITLE
Fix Last.fm accent handling

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -4,15 +4,6 @@ This file documents outstanding bugs discovered during a code audit.
 Fixed issues have been moved to [FIXED_BUGS.md](FIXED_BUGS.md).
 
 
-## 54. Last.fm normalization strips accented characters
-`normalize` removes all non-ASCII characters so artists like "Beyoncé" are cached without the accent, causing mismatches.
-```
-_punct_re = re.compile(r"[^a-z0-9 ]")
-...
-text = _punct_re.sub("", text)
-```
-【F:services/lastfm.py†L21-L31】
-
 ## 55. `get_lastfm_track_info` makes API calls even when the API key is blank
 The function always queries Last.fm without validating `settings.lastfm_api_key`, leading to failing requests when no key is set.
 ```

--- a/FIXED_BUGS.md
+++ b/FIXED_BUGS.md
@@ -713,3 +713,15 @@ def parse_track_text(text: str) -> tuple[str, str]:
         artist = parts[-3] if len(parts) >= 3 else "Unknown Artist"
 ```
 【F:core/m3u.py†L165-L175】
+
+## 54. Last.fm normalization strips accented characters
+*Fixed.* `normalize` now preserves accented characters by transliterating them to ASCII equivalents before removing punctuation.
+```python
+    text = unicodedata.normalize("NFKD", text).encode("ascii", "ignore").decode("ascii")
+    text = text.lower()
+    text = _paren_re.sub("", text)
+    text = _punct_re.sub("", text)
+    text = _space_re.sub(" ", text)
+    return text.strip()
+```
+【F:services/lastfm.py†L26-L36】

--- a/services/lastfm.py
+++ b/services/lastfm.py
@@ -8,6 +8,7 @@ Provides Last.fm integration for:
 
 import logging
 import re
+import unicodedata
 import asyncio
 import httpx
 
@@ -29,6 +30,8 @@ _space_re = re.compile(r"\s+")
 
 def normalize(text: str) -> str:
     """Standardize text for caching and comparison."""
+    # Normalize accents to their ASCII equivalents before lowercasing
+    text = unicodedata.normalize("NFKD", text).encode("ascii", "ignore").decode("ascii")
     text = text.lower()
     text = _paren_re.sub("", text)  # Remove content in parentheses
     text = _punct_re.sub("", text)  # Remove punctuation

--- a/tests/test_lastfm.py
+++ b/tests/test_lastfm.py
@@ -49,3 +49,9 @@ def test_normalize_long_open_parens(monkeypatch):
     normalize = _load_normalize(monkeypatch)
     text = "(" * 500 + "Example"
     assert normalize(text) == "example"
+
+
+def test_normalize_accents(monkeypatch):
+    """Accented characters should be converted to their ASCII equivalents."""
+    normalize = _load_normalize(monkeypatch)
+    assert normalize("Beyonc\u00e9") == "beyonce"


### PR DESCRIPTION
## Summary
- normalize accented characters in Last.fm helper
- test accent handling in `normalize`
- move resolved bug 54 to `FIXED_BUGS.md`

## Testing
- `pylint core api services utils`
- `PYTHONPATH=$PWD pytest`

------
https://chatgpt.com/codex/tasks/task_e_688b47791bf08332b24818d862f8fa91