### PR TITLE
Fix duration helper crash on invalid BPM

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -5,14 +5,6 @@ Fixed issues have been moved to [FIXED_BUGS.md](FIXED_BUGS.md).
 
 
 
-## 56. `_duration_from_ticks` may crash on non-numeric BPM data
-The helper casts the BPM API's ``duration`` field directly to ``int`` without validating its type.
-```
-bpm_duration = bpm_data.get("duration")
-return int(bpm_duration) if bpm_duration is not None else duration
-```
-【F:core/playlist.py†L287-L291】
-
 ## 57. `parse_gpt_line` ignores em dashes
 Only en dashes are normalized, so lines using an em dash (`—`) fail to parse.
 ```

--- a/FIXED_BUGS.md
+++ b/FIXED_BUGS.md
@@ -735,3 +735,17 @@ def parse_track_text(text: str) -> tuple[str, str]:
         return None
 ```
 【F:services/lastfm.py†L93-L98】
+
+## 56. `_duration_from_ticks` may crash on non-numeric BPM data
+*Fixed.* The helper now handles invalid ``duration`` values gracefully and logs a warning.
+```python
+    duration = int(ticks / 10_000_000) if ticks else 0
+    bpm_duration = bpm_data.get("duration")
+    if bpm_duration is not None:
+        try:
+            return int(bpm_duration)
+        except (TypeError, ValueError):
+            logger.warning("Invalid BPM duration: %s", bpm_duration)
+    return duration
+```
+【F:core/playlist.py†L291-L300】

--- a/core/playlist.py
+++ b/core/playlist.py
@@ -292,7 +292,12 @@ def _duration_from_ticks(ticks: int, bpm_data: dict) -> int:
     """Convert Jellyfin run-time ticks to seconds, falling back to BPM data."""
     duration = int(ticks / 10_000_000) if ticks else 0
     bpm_duration = bpm_data.get("duration")
-    return int(bpm_duration) if bpm_duration is not None else duration
+    if bpm_duration is not None:
+        try:
+            return int(bpm_duration)
+        except (TypeError, ValueError):
+            logger.warning("Invalid BPM duration: %s", bpm_duration)
+    return duration
 
 
 async def _classify_mood(

--- a/tests/test_duration_helper.py
+++ b/tests/test_duration_helper.py
@@ -1,0 +1,30 @@
+import ast
+from pathlib import Path
+import logging
+
+
+def _load_func(name):
+    src = Path("core/playlist.py").read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    func = next(
+        n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name == name
+    )
+    module = ast.Module(body=[func], type_ignores=[])
+    ns = {"logger": logging.getLogger("test")}
+    exec(compile(module, filename=f"<{name}>", mode="exec"), ns)
+    return ns[name]
+
+
+duration_from_ticks = _load_func("_duration_from_ticks")
+
+
+def test_duration_from_ticks_with_bpm():
+    assert duration_from_ticks(50_000_000, {"duration": "300"}) == 300
+
+
+def test_duration_from_ticks_invalid_bpm():
+    assert duration_from_ticks(50_000_000, {"duration": "oops"}) == 5
+
+
+def test_duration_from_ticks_missing():
+    assert duration_from_ticks(0, {"duration": None}) == 0


### PR DESCRIPTION
## Summary
- handle invalid BPM data in `_duration_from_ticks`
- record bug fix in `FIXED_BUGS.md`
- remove bug from `BUGS.md`
- test duration helper behaviour

## Testing
- `black .`
- `pylint core api services utils`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b4b2c971883328c507fc74def6ebe