### PR TITLE
Improve duration helper test docs

### DIFF
--- a/tests/test_duration_helper.py
+++ b/tests/test_duration_helper.py
@@ -1,9 +1,13 @@
+"""Tests for the ``_duration_from_ticks`` helper."""
+
 import ast
-from pathlib import Path
 import logging
+from pathlib import Path
 
 
 def _load_func(name):
+    """Load a single function from ``core.playlist`` without side effects."""
+
     src = Path("core/playlist.py").read_text(encoding="utf-8")
     tree = ast.parse(src)
     func = next(
@@ -11,7 +15,10 @@ def _load_func(name):
     )
     module = ast.Module(body=[func], type_ignores=[])
     ns = {"logger": logging.getLogger("test")}
-    exec(compile(module, filename=f"<{name}>", mode="exec"), ns)
+    exec(  # pylint: disable=exec-used
+        compile(module, filename=f"<{name}>", mode="exec"),
+        ns,
+    )
     return ns[name]
 
 
@@ -19,12 +26,18 @@ duration_from_ticks = _load_func("_duration_from_ticks")
 
 
 def test_duration_from_ticks_with_bpm():
+    """BPM data should override the tick-based duration."""
+
     assert duration_from_ticks(50_000_000, {"duration": "300"}) == 300
 
 
 def test_duration_from_ticks_invalid_bpm():
+    """Invalid BPM values should fall back to tick duration."""
+
     assert duration_from_ticks(50_000_000, {"duration": "oops"}) == 5
 
 
 def test_duration_from_ticks_missing():
+    """No duration data should yield zero seconds."""
+
     assert duration_from_ticks(0, {"duration": None}) == 0


### PR DESCRIPTION
## Summary
- document tests for `_duration_from_ticks`
- clarify helper loader usage and silence pylint `exec-used`

## Testing
- `black .`
- `pylint core api services utils`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b4cca29088332997fdb0fd85b187a