### PR TITLE
Fix GPT line parsing for em dashes

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -5,13 +5,6 @@ Fixed issues have been moved to [FIXED_BUGS.md](FIXED_BUGS.md).
 
 
 
-## 57. `parse_gpt_line` ignores em dashes
-Only en dashes are normalized, so lines using an em dash (`—`) fail to parse.
-```
-line = line.replace("\u2013", "-").strip()  # normalize en dash
-```
-【F:services/gpt.py†L181-L201】
-
 ## 58. `_extract_remaining` splits on every dash
 When titles or artists contain dashes, the remaining text is truncated because the helper splits on ``" - "`` without limit.
 ```

--- a/FIXED_BUGS.md
+++ b/FIXED_BUGS.md
@@ -749,3 +749,10 @@ def parse_track_text(text: str) -> tuple[str, str]:
     return duration
 ```
 【F:core/playlist.py†L291-L300】
+
+## 57. `parse_gpt_line` ignores em dashes
+*Fixed.* The parser now normalizes both en and em dashes so lines using an em dash parse correctly.
+```python
+    line = re.sub(r"[\u2013\u2014]", "-", line).strip()  # normalize en/em dashes
+```
+【F:services/gpt.py†L183-L205】

--- a/services/gpt.py
+++ b/services/gpt.py
@@ -189,7 +189,7 @@ def parse_gpt_line(line: str) -> tuple[str, str]:
     ``ValueError`` is raised.
     """
 
-    line = line.replace("\u2013", "-").strip()  # normalize en dash
+    line = re.sub(r"[\u2013\u2014]", "-", line).strip()  # normalize en/em dashes
 
     # Attempt to parse the common "Song - Artist" style first
     parts = [p.strip() for p in line.split(" - ")]

--- a/tests/test_gpt_jellyfin.py
+++ b/tests/test_gpt_jellyfin.py
@@ -148,6 +148,10 @@ def test_parse_gpt_line():
     assert title == "Another Song"
     assert artist == "Some Artist"
 
+    title, artist = parse_gpt_line("Em Dash Song — Em Dash Artist - Reason")
+    assert title == "Em Dash Song"
+    assert artist == "Em Dash Artist"
+
     with pytest.raises(ValueError):
         parse_gpt_line("Malformed line")
 


### PR DESCRIPTION
## Summary
- normalize both en and em dashes in `parse_gpt_line`
- cover em dash parsing in tests
- move bug 57 to fixed bug list

## Testing
- `black .`
- `pylint core api services utils`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_688de57baaac833297047ff051cbeb61