### PR TITLE
Fix test imports by configuring PYTHONPATH

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -3,4 +3,4 @@
 This file documents outstanding bugs discovered during a code audit.
 Fixed issues have been moved to [FIXED_BUGS.md](FIXED_BUGS.md).
 
-No outstanding bugs have been documented at this time.
+No outstanding bugs have been documented at this time. (Updated after resolving module import failures in the test suite.)

--- a/FIXED_BUGS.md
+++ b/FIXED_BUGS.md
@@ -764,3 +764,12 @@ def parse_track_text(text: str) -> tuple[str, str]:
     return parts[2].strip() if len(parts) > 2 else ""
 ```
 【F:services/gpt.py†L307-L318】
+
+## 59. Tests could not import project modules
+*Fixed.* Added a `conftest.py` that ensures the repository root is on `sys.path`, allowing the test suite to import local packages.
+```python
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+```
+【F:tests/conftest.py†L4-L9】

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+"""Pytest configuration and fixtures."""
+
+import sys
+from pathlib import Path
+
+# Ensure repository root is on PYTHONPATH for direct test execution
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))


### PR DESCRIPTION
## Summary
- add pytest `conftest.py` to put the repository root on `sys.path`
- document resolution of test import failure in BUGS and FIXED_BUGS lists

## Testing
- `black .`
- `pylint core api services utils`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688dec4a95408332bf274a88afb21e62