### PR TITLE
Expose integration watchdog metrics

### DIFF
--- a/api/forms.py
+++ b/api/forms.py
@@ -34,6 +34,7 @@ class SettingsForm(AppSettings):
         lyrics_weight: float = Form(1.5),
         bpm_weight: float = Form(1.0),
         tags_weight: float = Form(0.7),
+        integration_failure_limit: int = Form(3),
     ) -> "SettingsForm":
         """Create a SettingsForm instance from submitted form data."""
 
@@ -76,4 +77,5 @@ class SettingsForm(AppSettings):
             lyrics_weight=lyrics_weight,
             bpm_weight=bpm_weight,
             tags_weight=tags_weight,
+            integration_failure_limit=integration_failure_limit,
         )

--- a/api/routes.py
+++ b/api/routes.py
@@ -85,6 +85,7 @@ from utils.helpers import (
     parse_suggest_request,
     get_log_excerpt,
 )
+from utils.integration_watchdog import get_failure_counts
 from api.forms import SettingsForm
 from api.schemas import (
     HealthResponse,
@@ -352,6 +353,12 @@ async def delete_history(request: Request):
 async def health_check():
     """Simple endpoint for container liveness monitoring."""
     return {"status": "ok"}
+
+
+@router.get("/api/integration-failures", tags=["Monitoring"])
+async def integration_failures() -> dict[str, int]:
+    """Return current integration failure counters."""
+    return get_failure_counts()
 
 
 @router.get("/settings", response_class=HTMLResponse, tags=["Settings"])

--- a/config.py
+++ b/config.py
@@ -46,6 +46,8 @@ class AppSettings(BaseModel):
         lastfm_api_key (str): Optional key for Last.fm integration.
         model (str): GPT model to use (default is 'gpt-4o-mini').
         lyrics_enabled (bool): Toggle for lyrics-based mood analysis.
+        integration_failure_limit (int): Consecutive integration failures
+            before logging warnings.
     """
 
     jellyfin_url: str = ""
@@ -89,6 +91,7 @@ class AppSettings(BaseModel):
     lyrics_weight: float = 1.5
     bpm_weight: float = 1.0
     tags_weight: float = 0.7
+    integration_failure_limit: int = 3
 
     def clear_cache(self, name: str | None = None) -> None:
         """Clear one or all disk caches.

--- a/templates/base.html
+++ b/templates/base.html
@@ -17,6 +17,8 @@
     {{ macros.nav(request) }}
   </nav>
 
+  <div id="integration-failures" class="text-center text-red-600 text-sm"></div>
+
   <main class="max-w-screen-xl mx-auto p-4">
     {% block content %}{% endblock %}
   </main>
@@ -24,6 +26,18 @@
   <footer class="mt-8 bg-gray-200 dark:bg-gray-800 text-center p-4 text-sm text-gray-700 dark:text-gray-300">
     <p>Playlist Pilot — Curate your soundtrack.</p>
   </footer>
-
+  <script>
+    fetch('/api/integration-failures')
+      .then(r => r.json())
+      .then(data => {
+        const el = document.getElementById('integration-failures');
+        const entries = Object.entries(data);
+        if (entries.length) {
+          el.textContent = 'Integration failures: ' +
+            entries.map(([k, v]) => `${k} (${v})`).join(', ');
+        }
+      })
+      .catch(() => {});
+  </script>
 </body>
 </html>

--- a/utils/integration_watchdog.py
+++ b/utils/integration_watchdog.py
@@ -3,9 +3,10 @@
 from collections import defaultdict
 import logging
 
+from config import settings
+
 logger = logging.getLogger("playlist-pilot")
 
-_FAILURE_THRESHOLD = 3
 _failure_counts: defaultdict[str, int] = defaultdict(int)
 
 
@@ -20,7 +21,7 @@ def record_failure(service: str) -> None:
     _failure_counts[service] += 1
     count = _failure_counts[service]
     logger.error("[watchdog] %s failure #%d", service, count)
-    if count >= _FAILURE_THRESHOLD:
+    if count >= settings.integration_failure_limit:
         logger.warning("⚠️ %s integration repeatedly failing (%d)", service, count)
 
 


### PR DESCRIPTION
## Summary
- allow configuring integration failure limit via settings
- surface integration failure counts through new API and UI snippet

## Testing
- `pip install -r requirements.txt`
- `pip install pylint black pytest`
- `black .`
- `pylint core api services utils`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e974ff85083328660fef7fc75ff3d