### PR TITLE
chore: update TODO after watchdog fix

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,9 +2,6 @@
 
 This file outlines upcoming tasks based on the current roadmap and outstanding bugs.
 
-## Bug Fixes
-- [ ] **54. Integration watchdog threshold is hard-coded** – make the failure limit configurable and surface counts in the UI.
-
 ## Roadmap
 ### Phase 2 – Advanced Analysis & Playlist Management
 - [ ] Add playlist management tools for renaming and reordering.
@@ -13,7 +10,6 @@ This file outlines upcoming tasks based on the current roadmap and outstanding b
 - [ ] Experiment with metadata/play link lookups from Spotify or Apple Music.
 - [ ] Optimize caching and async calls; enhance containerization.
 - [ ] Evaluate if/when real downloading support should be added.
-- [ ] Surface integration watchdog metrics in the UI and make the failure threshold configurable.
 
 ### Phase 4 – API Expansion & Future Explorations
 - [ ] Expand FastAPI endpoints into a fully documented API.


### PR DESCRIPTION
## Summary
- remove outdated integration watchdog TODO items

## Testing
- `black .`
- `pylint core api services utils`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e9b58877c8332ad9db3e43d1ec797