### PR TITLE
test: add Jellyfin timecode stripping tests

### DIFF
--- a/tests/test_jellyfin.py
+++ b/tests/test_jellyfin.py
@@ -1,0 +1,23 @@
+"""Tests for Jellyfin lyric helpers."""
+
+import pytest
+
+from services.jellyfin import strip_lrc_timecodes
+
+
+def test_strip_timecodes_basic():
+    """Timecodes preceding lyrics should be removed."""
+    line = "[01:23.45]Hello there"
+    assert strip_lrc_timecodes(line) == "Hello there"
+
+
+def test_strip_timecodes_preserves_annotation():
+    """Annotation brackets without timecodes remain unchanged."""
+    line = "[Chorus]"
+    assert strip_lrc_timecodes(line) == "[Chorus]"
+
+
+def test_strip_timecodes_combined_with_annotation():
+    """Only timecodes are stripped when combined with annotations."""
+    line = "[02:03.45][Chorus]Sing along"
+    assert strip_lrc_timecodes(line) == "[Chorus]Sing along"


### PR DESCRIPTION
## Summary
- add tests for Jellyfin `strip_lrc_timecodes` covering timecodes and annotations

## Testing
- `python -m black .`
- `python -m pylint core api services utils`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ea4193bd483328a4bb26c0b235c35