### PR TITLE
Validate library tracks and test missing fields

### DIFF
--- a/core/playlist.py
+++ b/core/playlist.py
@@ -155,8 +155,11 @@ async def get_full_audio_library(force_refresh: bool = False) -> list[str]:
             if isinstance(item, dict):
                 song = item.get("Name")
                 artist = item.get("AlbumArtist")
-                if song and artist:
-                    items.append(f"{song} - {artist}")
+                if isinstance(song, str) and isinstance(artist, str):
+                    song = song.strip()
+                    artist = artist.strip()
+                    if song and artist:
+                        items.append(f"{song} - {artist}")
         if len(chunk) < limit:
             break
         start_index += limit

--- a/tests/test_full_audio_library.py
+++ b/tests/test_full_audio_library.py
@@ -30,6 +30,20 @@ async def fake_jf_get(*_args, **_kwargs):
     }
 
 
+async def fake_jf_get_invalid_types(*_args, **_kwargs):
+    """Return items with empty strings or non-string fields."""
+    return {
+        "Items": [
+            {"Name": "Song 1", "AlbumArtist": "Artist 1"},
+            {"Name": "", "AlbumArtist": "Artist 2"},
+            {"Name": "Song 3", "AlbumArtist": ""},
+            {"Name": 123, "AlbumArtist": "Artist 4"},
+            {"Name": "Song 5", "AlbumArtist": ["Artist 5"]},
+            {"Name": "  Song 6  ", "AlbumArtist": " Artist 6 "},
+        ]
+    }
+
+
 def test_get_full_audio_library_skips_incomplete(monkeypatch):
     """Entries missing Name or AlbumArtist should be excluded."""
     monkeypatch.setattr(playlist, "jf_get", fake_jf_get)
@@ -39,3 +53,14 @@ def test_get_full_audio_library_skips_incomplete(monkeypatch):
         playlist.get_full_audio_library(force_refresh=True)
     )
     assert result == ["Song 1 - Artist 1"]
+
+
+def test_get_full_audio_library_strips_and_validates(monkeypatch):
+    """Ensure empty or non-string fields are excluded and whitespace trimmed."""
+    monkeypatch.setattr(playlist, "jf_get", fake_jf_get_invalid_types)
+    monkeypatch.setattr(playlist, "library_cache", DummyCache())
+    monkeypatch.setattr(playlist.settings, "jellyfin_user_id", "user", raising=False)
+    result = asyncio.get_event_loop().run_until_complete(
+        playlist.get_full_audio_library(force_refresh=True)
+    )
+    assert result == ["Song 1 - Artist 1", "Song 6 - Artist 6"]


### PR DESCRIPTION
## Summary
- ensure `get_full_audio_library` validates and trims track name and artist before caching
- extend tests to cover missing, empty, or non-string fields

## Testing
- `black .`
- `pylint core api services utils`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ea7d9f53c833289dff7ccda829f92