### PR TITLE
Add LRC timecode stripping tests

### DIFF
--- a/tests/test_jellyfin.py
+++ b/tests/test_jellyfin.py
@@ -7,8 +7,8 @@ from services.jellyfin import strip_lrc_timecodes
 
 def test_strip_timecodes_basic():
     """Timecodes preceding lyrics should be removed."""
-    line = "[01:23.45]Hello there"
-    assert strip_lrc_timecodes(line) == "Hello there"
+    line = "[01:23.45]Lyrics"
+    assert strip_lrc_timecodes(line) == "Lyrics"
 
 
 def test_strip_timecodes_preserves_annotation():
@@ -19,5 +19,5 @@ def test_strip_timecodes_preserves_annotation():
 
 def test_strip_timecodes_combined_with_annotation():
     """Only timecodes are stripped when combined with annotations."""
-    line = "[02:03.45][Chorus]Sing along"
-    assert strip_lrc_timecodes(line) == "[Chorus]Sing along"
+    line = "[02:03.45][Chorus]Lyrics"
+    assert strip_lrc_timecodes(line) == "[Chorus]Lyrics"


### PR DESCRIPTION
## Summary
- test Jellyfin lyric stripping to ensure timecodes are removed and annotations remain

## Testing
- `black tests/test_jellyfin.py`
- `pylint core api services utils`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68960edf9e4c83328fb048d99b0237c7