### PR TITLE
Close HTTP clients on shutdown

### DIFF
--- a/main.py
+++ b/main.py
@@ -26,6 +26,7 @@ from fastapi.staticfiles import StaticFiles
 from api.routes import router as main_router
 from config import settings
 from core.constants import BASE_DIR, LOG_FILE
+from utils.http_client import aclose_http_clients
 
 
 # ─────────────────────────────────────────────────────────────
@@ -57,6 +58,13 @@ app = FastAPI(title="Playlist Pilot")
 app.include_router(main_router)
 # Serve static files (CSS, JS, etc.)
 app.mount("/static", StaticFiles(directory=str(BASE_DIR / "static")), name="static")
+
+
+@app.on_event("shutdown")
+async def shutdown_event() -> None:
+    """Close shared HTTP clients on application shutdown."""
+    await aclose_http_clients()
+
 
 # ─────────────────────────────────────────────────────────────
 # Additional routes and startup events could be added here.

--- a/tests/test_shutdown_event.py
+++ b/tests/test_shutdown_event.py
@@ -1,0 +1,30 @@
+import importlib
+import sys
+from fastapi.testclient import TestClient
+
+
+def test_shutdown_closes_http_clients() -> None:
+    """Shutdown event closes shared HTTP clients."""
+    for module in [
+        "httpx",
+        "utils.http_client",
+        "utils.cache_manager",
+        "utils.helpers",
+        "api.routes",
+        "main",
+        "diskcache",
+    ]:
+        sys.modules.pop(module, None)
+
+    importlib.import_module("httpx")
+    from main import app
+    from utils import http_client
+
+    long_client = http_client.get_http_client()
+    short_client = http_client.get_http_client(short=True)
+
+    with TestClient(app):
+        pass
+
+    assert long_client.is_closed
+    assert short_client.is_closed


### PR DESCRIPTION
## Summary
- ensure FastAPI shutdown closes shared HTTP clients
- add regression test verifying HTTP clients are closed

## Testing
- `pylint core api services utils`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896118a170483328988a543a908fc61