### PR TITLE
chore: resolve lint warnings in tests

### DIFF
--- a/tests/test_jellyfin.py
+++ b/tests/test_jellyfin.py
@@ -1,7 +1,5 @@
 """Tests for Jellyfin lyric helpers."""
 
-import pytest
-
 from services.jellyfin import strip_lrc_timecodes
 
 

--- a/tests/test_shutdown_event.py
+++ b/tests/test_shutdown_event.py
@@ -1,3 +1,5 @@
+"""Tests for the application's shutdown event."""
+
 import importlib
 import sys
 from fastapi.testclient import TestClient
@@ -17,13 +19,13 @@ def test_shutdown_closes_http_clients() -> None:
         sys.modules.pop(module, None)
 
     importlib.import_module("httpx")
-    from main import app
-    from utils import http_client
+    app_module = importlib.import_module("main")
+    http_client_module = importlib.import_module("utils.http_client")
 
-    long_client = http_client.get_http_client()
-    short_client = http_client.get_http_client(short=True)
+    long_client = http_client_module.get_http_client()
+    short_client = http_client_module.get_http_client(short=True)
 
-    with TestClient(app):
+    with TestClient(app_module.app):
         pass
 
     assert long_client.is_closed


### PR DESCRIPTION
## Summary
- remove unused pytest import from Jellyfin tests
- add module docstring and move shutdown test imports to importlib for pylint compliance

## Testing
- `pip install -r requirements.txt`
- `pip install pylint black pytest`
- `black .`
- `pylint core api services utils tests/test_jellyfin.py tests/test_shutdown_event.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689618a0495483329997e3b4e81ff92e