### PR TITLE
Add request models for suggestion and import routes

### DIFF
--- a/api/schemas.py
+++ b/api/schemas.py
@@ -2,6 +2,7 @@
 
 from typing import Any, Dict, List, Optional
 from pydantic import BaseModel
+from fastapi import UploadFile
 
 
 class HealthResponse(BaseModel):
@@ -101,6 +102,35 @@ class OrderSuggestionResponse(BaseModel):
     """Response model for GPT ordering suggestions."""
 
     ordered_tracks: List[TrackRef]
+
+
+class SuggestFromAnalyzedRequest(BaseModel):
+    """Request model for generating suggestions from analyzed tracks."""
+
+    tracks: List[TrackRef]
+    playlist_name: str
+    text_summary: Optional[str] = None
+
+
+class SuggestFromAnalyzedResponse(BaseModel):
+    """Response model for playlist suggestions."""
+
+    suggestions: List[TrackRef]
+    download_link: str
+    count: int
+    playlist_name: str
+
+
+class ImportM3URequest(BaseModel):
+    """Request model for importing an M3U file."""
+
+    m3u_file: UploadFile
+
+
+class ImportM3UResponse(BaseModel):
+    """Response model for M3U imports."""
+
+    message: str
 
 
 class ExportPlaylistResponse(BaseModel):

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -73,7 +73,9 @@ def _extract_import_m3u_file():
     )
     func.decorator_list = []
     func.args.defaults = []
-    func.args.args[0].annotation = None
+    func.args.kw_defaults = []
+    for arg in func.args.args[:2]:
+        arg.annotation = None
     func.returns = None
     module = ast.Module(body=[func], type_ignores=[])
     ns = {
@@ -106,9 +108,13 @@ def test_export_m3u_no_tracks():
 
 def test_import_m3u_file_invalid_extension(tmp_path):
     """Invalid file extensions should result in ``HTTPException``."""
-    dummy = UploadFile(tmp_path / "test.txt", filename="test.txt")
+    dummy_file = UploadFile(tmp_path / "test.txt", filename="test.txt")
+    dummy_req = types.SimpleNamespace(headers={})
+    dummy_payload = types.SimpleNamespace(m3u_file=dummy_file)
     import_m3u = _extract_import_m3u_file()
 
     with pytest.raises(HTTPException) as exc:
-        asyncio.get_event_loop().run_until_complete(import_m3u(dummy))
+        asyncio.get_event_loop().run_until_complete(
+            import_m3u(dummy_req, dummy_payload)
+        )
     assert exc.value.status_code == 400


### PR DESCRIPTION
## Summary
- add `SuggestFromAnalyzedRequest`/`SuggestFromAnalyzedResponse` and use them in the suggestion route
- add `ImportM3URequest` and `ImportM3UResponse` for the M3U import endpoint
- expand tests for new request models

## Testing
- `pylint core api services utils`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68961a4ffb6083329e1d953cc2d624d0