### PR TITLE
Document integration failure metrics endpoint

### DIFF
--- a/Docs/api_reference.md
+++ b/Docs/api_reference.md
@@ -5,7 +5,6 @@ The table below summarises the main endpoints exposed by Playlist Pilot. All end
 | Method | Path | Description |
 |-------|------|-------------|
 | GET | `/` | Home page showing Jellyfin playlists and history |
-| POST | `/suggest` | Generate a playlist from manual input |
 | GET | `/analyze` | Choose a playlist for analysis |
 | POST | `/analyze/result` | Display analysis results |
 | POST | `/analyze/export-m3u` | Export analyzed tracks as M3U |
@@ -23,7 +22,10 @@ The table below summarises the main endpoints exposed by Playlist Pilot. All end
 | POST | `/settings` | Update settings |
 | POST | `/api/test/lastfm` | Verify Last.fm connectivity |
 | POST | `/api/test/jellyfin` | Verify Jellyfin connectivity |
+| POST | `/api/test/openai` | Verify OpenAI connectivity |
+| POST | `/api/test/getsongbpm` | Verify GetSongBPM connectivity |
 | POST | `/api/verify-entry` | Verify a playlist entry ID |
+| GET | `/api/integration-failures` | Current integration failure counters |
 | GET | `/health` | Simple health check |
 
 Return codes generally follow HTTP conventions: 200 for success, 4xx for invalid input and 5xx for unexpected errors.

--- a/api/routes.py
+++ b/api/routes.py
@@ -100,6 +100,7 @@ from api.schemas import (  # pylint: disable=unused-import
     VerifyEntryRequest,
     VerifyEntryResponse,
     TagsResponse,
+    IntegrationFailuresResponse,
     OrderSuggestionResponse,
     TrackRef,
     ExportPlaylistResponse,
@@ -360,10 +361,14 @@ async def health_check():
     return {"status": "ok"}
 
 
-@router.get("/api/integration-failures", tags=["Monitoring"])
-async def integration_failures() -> dict[str, int]:
+@router.get(
+    "/api/integration-failures",
+    response_model=IntegrationFailuresResponse,
+    tags=["Monitoring"],
+)
+async def integration_failures() -> IntegrationFailuresResponse:
     """Return current integration failure counters."""
-    return get_failure_counts()
+    return IntegrationFailuresResponse(failures=get_failure_counts())
 
 
 @router.get("/settings", response_class=HTMLResponse, tags=["Settings"])

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -91,6 +91,12 @@ class TagsResponse(BaseModel):
     tags: List[str]
 
 
+class IntegrationFailuresResponse(BaseModel):
+    """Response model for integration failure counters."""
+
+    failures: Dict[str, int]
+
+
 class TrackRef(BaseModel):
     """Reference to a track by title and artist."""
 


### PR DESCRIPTION
## Summary
- add IntegrationFailuresResponse model and wire it into `/api/integration-failures`
- document monitoring and testing endpoints in API reference

## Testing
- `black api/routes.py api/schemas.py`
- `pylint core api services utils`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68961cfb072c8332a58db2dfdef2a531