### PR TITLE
Refactor API routes into modular package

### DIFF
--- a/api/routes/__init__.py
+++ b/api/routes/__init__.py
@@ -1,0 +1,14 @@
+"""Combined API routers for Playlist Pilot."""
+
+from fastapi import APIRouter
+
+from .analysis_routes import router as analysis_router
+from .settings_routes import router as settings_router
+from .monitoring_routes import router as monitoring_router
+
+router = APIRouter()
+router.include_router(analysis_router)
+router.include_router(settings_router)
+router.include_router(monitoring_router)
+
+__all__ = ["router"]

--- a/api/routes/analysis_routes.py
+++ b/api/routes/analysis_routes.py
@@ -1,17 +1,4 @@
-"""
-routes.py
-
-This module defines all FastAPI route handlers for Playlist Pilot,
-including:
-
-- Home page with playlist suggestions
-- GPT-augmented suggestion flow
-- Playlist comparison
-- User history view and deletion
-- Settings management
-"""
-
-# pylint: disable=too-many-lines
+"""FastAPI routes for playlist analysis and related features."""
 
 import logging
 import shutil
@@ -20,12 +7,6 @@ import uuid
 from pathlib import Path
 from time import perf_counter
 
-import asyncio
-from urllib.parse import quote_plus
-
-import httpx
-import openai
-import cloudscraper
 from fastapi import (
     APIRouter,
     Request,
@@ -39,10 +20,7 @@ from fastapi import (
 from fastapi.responses import HTMLResponse, JSONResponse, FileResponse, RedirectResponse
 from starlette.background import BackgroundTask
 
-from config import (
-    save_settings,
-    settings,
-)
+from config import settings
 from core.analysis import summarize_tracks, add_combined_popularity
 from core.history import (
     extract_date_from_label,
@@ -68,13 +46,11 @@ from services.gpt import (
     generate_playlist_analysis_summary,
     fetch_gpt_suggestions,
     fetch_order_suggestions,
-    fetch_openai_models,
     format_removal_suggestions,
 )
 from services.jellyfin import (
     create_jellyfin_playlist,
     fetch_jellyfin_track_metadata,
-    fetch_jellyfin_users,
     fetch_tracks_for_playlist_id,
     resolve_jellyfin_path,
 )
@@ -85,26 +61,12 @@ from utils.helpers import (
     parse_suggest_request,
     get_log_excerpt,
 )
-from utils.integration_watchdog import get_failure_counts
-from api.forms import SettingsForm
 from api.schemas import (  # pylint: disable=unused-import
-    HealthResponse,
-    LastfmTestRequest,
-    LastfmTestResponse,
-    JellyfinTestRequest,
-    JellyfinTestResponse,
-    OpenAITestRequest,
-    OpenAITestResponse,
-    GetSongBPMTestRequest,
-    GetSongBPMTestResponse,
-    VerifyEntryRequest,
-    VerifyEntryResponse,
     TagsResponse,
-    IntegrationFailuresResponse,
     OrderSuggestionResponse,
     TrackRef,
     ExportPlaylistResponse,
-    AnalysisExportRequest,  # pylint: disable=unused-import
+    AnalysisExportRequest,
     ExportTrackMetadataRequest,
     ExportTrackMetadataResponse,
     SuggestFromAnalyzedRequest,
@@ -112,7 +74,6 @@ from api.schemas import (  # pylint: disable=unused-import
     ImportM3URequest,
     ImportM3UResponse,
 )
-
 
 logger = logging.getLogger("playlist-pilot")
 
@@ -353,259 +314,6 @@ async def delete_history(request: Request):
     entry_id = raw_id if isinstance(raw_id, str) else ""
     delete_history_entry_by_id(settings.jellyfin_user_id, entry_id)
     return RedirectResponse(url="/history", status_code=303)
-
-
-@router.get("/health", response_model=HealthResponse, tags=["System"])
-async def health_check():
-    """Simple endpoint for container liveness monitoring."""
-    return {"status": "ok"}
-
-
-@router.get(
-    "/api/integration-failures",
-    response_model=IntegrationFailuresResponse,
-    tags=["Monitoring"],
-)
-async def integration_failures() -> IntegrationFailuresResponse:
-    """Return current integration failure counters."""
-    return IntegrationFailuresResponse(failures=get_failure_counts())
-
-
-@router.get("/settings", response_class=HTMLResponse, tags=["Settings"])
-async def get_settings(request: Request):
-    """Display current configuration and available Jellyfin users."""
-    try:
-        settings.validate_settings()
-        validation_message = None
-        validation_error = False
-    except ValueError as ve:
-        validation_message = str(ve)
-        validation_error = True
-    users = await fetch_jellyfin_users()
-    models = await fetch_openai_models(settings.openai_api_key)
-    log_excerpt = get_log_excerpt()
-
-    return templates.TemplateResponse(
-        "settings.html",
-        {
-            "request": request,
-            "settings": settings.dict(),
-            "models": models,
-            "validation_message": validation_message,
-            "validation_error": validation_error,
-            "jellyfin_users": users,
-            "log_excerpt": log_excerpt,
-        },
-    )
-
-
-@router.post("/settings", response_class=HTMLResponse, tags=["Settings"])
-async def update_settings(
-    request: Request,
-    form_data: SettingsForm = Depends(SettingsForm.as_form),
-):
-    """Update application configuration settings from form input."""
-    settings.jellyfin_url = form_data.jellyfin_url
-    settings.jellyfin_api_key = form_data.jellyfin_api_key
-    settings.jellyfin_user_id = form_data.jellyfin_user_id
-    settings.openai_api_key = form_data.openai_api_key
-    settings.lastfm_api_key = form_data.lastfm_api_key
-    settings.model = form_data.model
-    models = await fetch_openai_models(settings.openai_api_key)
-    settings.getsongbpm_api_key = form_data.getsongbpm_api_key
-    settings.global_min_lfm = form_data.global_min_lfm
-    settings.global_max_lfm = form_data.global_max_lfm
-    settings.cache_ttls = form_data.cache_ttls
-    # Update shared cache TTLs in-place so other modules
-    # that imported the dictionary see the new values
-    # Import lazily to avoid a circular dependency
-    from utils import cache_manager  # pylint: disable=import-outside-toplevel
-
-    cache_manager.CACHE_TTLS.clear()
-    cache_manager.CACHE_TTLS.update(settings.cache_ttls)
-    settings.getsongbpm_base_url = form_data.getsongbpm_base_url
-    settings.getsongbpm_headers = form_data.getsongbpm_headers
-    settings.http_timeout_short = form_data.http_timeout_short
-    settings.http_timeout_long = form_data.http_timeout_long
-    settings.youtube_min_duration = form_data.youtube_min_duration
-    settings.youtube_max_duration = form_data.youtube_max_duration
-    settings.library_scan_limit = form_data.library_scan_limit
-    settings.music_library_root = form_data.music_library_root
-    settings.lyrics_enabled = form_data.lyrics_enabled
-    settings.lyrics_weight = form_data.lyrics_weight
-    settings.bpm_weight = form_data.bpm_weight
-    settings.tags_weight = form_data.tags_weight
-
-    try:
-        settings.validate_settings()
-        save_settings(settings)
-        validation_message = "Settings saved successfully."
-        validation_error = False
-    except ValueError as ve:
-        validation_message = str(ve)
-        validation_error = True
-
-    users = await fetch_jellyfin_users()
-    log_excerpt = get_log_excerpt()
-    return templates.TemplateResponse(
-        "settings.html",
-        {
-            "request": request,
-            "settings": settings.dict(),
-            "validation_message": validation_message,
-            "validation_error": validation_error,
-            "models": models,
-            "jellyfin_users": users,
-            "log_excerpt": log_excerpt,
-        },
-    )
-
-
-@router.post("/api/test/lastfm", response_model=LastfmTestResponse, tags=["Testing"])
-async def test_lastfm(payload: LastfmTestRequest) -> LastfmTestResponse:
-    """Validate a Last.fm API key by performing a simple artist search."""
-    key = payload.key.strip()
-
-    try:
-        async with httpx.AsyncClient() as client:
-            r = await client.get(
-                "https://ws.audioscrobbler.com/2.0/",
-                params={
-                    "method": "artist.search",
-                    "artist": "radiohead",
-                    "api_key": key,
-                    "format": "json",
-                },
-            )
-
-        json_data = r.json()
-        return LastfmTestResponse(
-            success="error" not in json_data,
-            status=r.status_code,
-            body=json_data,
-        )
-    except httpx.HTTPError as exc:
-        logger.error("HTTP error during Last.fm API test: %s", str(exc))
-        return LastfmTestResponse(
-            success=False,
-            error="An internal error occurred while testing the Last.fm API.",
-        )
-
-
-@router.post(
-    "/api/test/jellyfin", response_model=JellyfinTestResponse, tags=["Testing"]
-)
-async def test_jellyfin(payload: JellyfinTestRequest) -> JellyfinTestResponse:
-    """Verify the provided Jellyfin URL and API key."""
-    url = payload.url.rstrip("/")
-    key = payload.key
-
-    try:
-        headers = {
-            "X-Emby-Token": key,
-            "Accept": "application/json",
-            "User-Agent": "PlaylistPilotTest/1.0",
-        }
-        async with httpx.AsyncClient() as client:
-            r = await client.get(f"{url}/System/Info", headers=headers)
-        logger.debug("Jellyfin Test: %s", r.text)
-
-        json_data = r.json()
-        valid = r.status_code == 200 and any(k.lower() == "version" for k in json_data)
-        return JellyfinTestResponse(success=valid, status=r.status_code, data=json_data)
-    except httpx.HTTPError as exc:
-        logger.error("HTTP error during Jellyfin API test: %s", str(exc))
-        return JellyfinTestResponse(
-            success=False,
-            error="An internal error occurred while testing the Jellyfin API.",
-        )
-
-
-@router.post("/api/test/openai", response_model=OpenAITestResponse, tags=["Testing"])
-async def test_openai(payload: OpenAITestRequest) -> OpenAITestResponse:
-    """Check if the OpenAI API key is valid by listing available models."""
-    key = payload.key
-    try:
-
-        def _list_models():
-            client = openai.OpenAI(api_key=key)
-            return client.models.list()
-
-        models = await asyncio.to_thread(_list_models)
-        valid = any(m.id.startswith("gpt") for m in models.data)
-        return OpenAITestResponse(success=valid)
-    except openai.OpenAIError as exc:
-        logger.error("OpenAI test error: %s", str(exc))
-        return OpenAITestResponse(
-            success=False,
-            error="An internal error has occurred. Please try again later.",
-        )
-
-
-@router.post(
-    "/api/test/getsongbpm",
-    response_model=GetSongBPMTestResponse,
-    tags=["Testing"],
-)
-async def test_getsongbpm(payload: GetSongBPMTestRequest) -> GetSongBPMTestResponse:
-    """Check if the GetSongBPM API key is valid by performing a sample query."""
-    key = payload.key
-    lookup = quote_plus("song:creep artist:radiohead")
-    url = f"{settings.getsongbpm_base_url}?api_key={key}&type=both&lookup={lookup}"
-    try:
-
-        def _fetch():
-            return cloudscraper.create_scraper(browser="chrome").get(
-                url,
-                headers=settings.getsongbpm_headers,
-                timeout=settings.http_timeout_short,
-            )
-
-        r = await asyncio.to_thread(_fetch)
-
-        try:
-            json_data = r.json()
-        except ValueError as exc:  # json.JSONDecodeError inherits from ValueError
-            logger.error("JSON decode error during GetSongBPM API test: %s", str(exc))
-            return GetSongBPMTestResponse(
-                success=False,
-                status=r.status_code,
-                error="Invalid JSON response from GetSongBPM.",
-            )
-        valid = r.status_code == 200 and "search" in json_data
-        return GetSongBPMTestResponse(
-            success=valid, status=r.status_code, data=json_data
-        )
-    except Exception as exc:  # pylint: disable=broad-exception-caught
-        logger.error("HTTP error during GetSongBPM API test: %s", str(exc))
-        return GetSongBPMTestResponse(
-            success=False,
-            error="An internal error occurred while testing the GetSongBPM API.",
-        )
-
-
-@router.post(
-    "/api/verify-entry",
-    response_model=VerifyEntryResponse,
-    tags=["Jellyfin"],
-)
-async def verify_playlist_entry(payload: VerifyEntryRequest) -> VerifyEntryResponse:
-    """Confirm that a playlist contains the specified entry ID."""
-    playlist_id = payload.playlist_id
-    entry_id = payload.entry_id
-
-    if not playlist_id or not entry_id:
-        return VerifyEntryResponse(
-            success=False, error="playlist_id and entry_id are required"
-        )
-
-    tracks = await fetch_tracks_for_playlist_id(playlist_id)
-    match = next((t for t in tracks if t.get("PlaylistItemId") == entry_id), None)
-
-    if match:
-        return VerifyEntryResponse(success=True, track=match)
-
-    return VerifyEntryResponse(success=False, error="Entry not found in playlist")
 
 
 @router.get("/analyze", response_class=HTMLResponse, tags=["Analysis"])

--- a/api/routes/monitoring_routes.py
+++ b/api/routes/monitoring_routes.py
@@ -1,0 +1,24 @@
+"""Monitoring and health check routes."""
+
+from fastapi import APIRouter
+
+from api.schemas import HealthResponse, IntegrationFailuresResponse
+from utils.integration_watchdog import get_failure_counts
+
+router = APIRouter()
+
+
+@router.get("/health", response_model=HealthResponse, tags=["System"])
+async def health_check():
+    """Simple endpoint for container liveness monitoring."""
+    return {"status": "ok"}
+
+
+@router.get(
+    "/api/integration-failures",
+    response_model=IntegrationFailuresResponse,
+    tags=["Monitoring"],
+)
+async def integration_failures() -> IntegrationFailuresResponse:
+    """Return current integration failure counters."""
+    return IntegrationFailuresResponse(failures=get_failure_counts())

--- a/api/routes/settings_routes.py
+++ b/api/routes/settings_routes.py
@@ -1,0 +1,271 @@
+"""FastAPI routes for application settings and integration tests."""
+
+import logging
+import asyncio
+from urllib.parse import quote_plus
+
+import httpx
+import openai
+import cloudscraper
+from fastapi import APIRouter, Request, Depends
+from fastapi.responses import HTMLResponse
+
+from config import save_settings, settings
+from core.templates import templates
+from services.gpt import fetch_openai_models
+from services.jellyfin import fetch_jellyfin_users, fetch_tracks_for_playlist_id
+from utils.helpers import get_log_excerpt
+from api.forms import SettingsForm
+from api.schemas import (
+    LastfmTestRequest,
+    LastfmTestResponse,
+    JellyfinTestRequest,
+    JellyfinTestResponse,
+    OpenAITestRequest,
+    OpenAITestResponse,
+    GetSongBPMTestRequest,
+    GetSongBPMTestResponse,
+    VerifyEntryRequest,
+    VerifyEntryResponse,
+)
+
+logger = logging.getLogger("playlist-pilot")
+
+router = APIRouter()
+
+
+@router.get("/settings", response_class=HTMLResponse, tags=["Settings"])
+async def get_settings(request: Request):
+    """Display current configuration and available Jellyfin users."""
+    try:
+        settings.validate_settings()
+        validation_message = None
+        validation_error = False
+    except ValueError as ve:
+        validation_message = str(ve)
+        validation_error = True
+    users = await fetch_jellyfin_users()
+    models = await fetch_openai_models(settings.openai_api_key)
+    log_excerpt = get_log_excerpt()
+
+    return templates.TemplateResponse(
+        "settings.html",
+        {
+            "request": request,
+            "settings": settings.dict(),
+            "models": models,
+            "validation_message": validation_message,
+            "validation_error": validation_error,
+            "jellyfin_users": users,
+            "log_excerpt": log_excerpt,
+        },
+    )
+
+
+@router.post("/settings", response_class=HTMLResponse, tags=["Settings"])
+async def update_settings(
+    request: Request,
+    form_data: SettingsForm = Depends(SettingsForm.as_form),
+):
+    """Update application configuration settings from form input."""
+    settings.jellyfin_url = form_data.jellyfin_url
+    settings.jellyfin_api_key = form_data.jellyfin_api_key
+    settings.jellyfin_user_id = form_data.jellyfin_user_id
+    settings.openai_api_key = form_data.openai_api_key
+    settings.lastfm_api_key = form_data.lastfm_api_key
+    settings.model = form_data.model
+    models = await fetch_openai_models(settings.openai_api_key)
+    settings.getsongbpm_api_key = form_data.getsongbpm_api_key
+    settings.global_min_lfm = form_data.global_min_lfm
+    settings.global_max_lfm = form_data.global_max_lfm
+    settings.cache_ttls = form_data.cache_ttls
+    # Update shared cache TTLs in-place so other modules
+    # that imported the dictionary see the new values
+    # Import lazily to avoid a circular dependency
+    from utils import cache_manager  # pylint: disable=import-outside-toplevel
+
+    cache_manager.CACHE_TTLS.clear()
+    cache_manager.CACHE_TTLS.update(settings.cache_ttls)
+    settings.getsongbpm_base_url = form_data.getsongbpm_base_url
+    settings.getsongbpm_headers = form_data.getsongbpm_headers
+    settings.http_timeout_short = form_data.http_timeout_short
+    settings.http_timeout_long = form_data.http_timeout_long
+    settings.youtube_min_duration = form_data.youtube_min_duration
+    settings.youtube_max_duration = form_data.youtube_max_duration
+    settings.library_scan_limit = form_data.library_scan_limit
+    settings.music_library_root = form_data.music_library_root
+    settings.lyrics_enabled = form_data.lyrics_enabled
+    settings.lyrics_weight = form_data.lyrics_weight
+    settings.bpm_weight = form_data.bpm_weight
+    settings.tags_weight = form_data.tags_weight
+
+    try:
+        settings.validate_settings()
+        save_settings(settings)
+        validation_message = "Settings saved successfully."
+        validation_error = False
+    except ValueError as ve:
+        validation_message = str(ve)
+        validation_error = True
+
+    users = await fetch_jellyfin_users()
+    log_excerpt = get_log_excerpt()
+    return templates.TemplateResponse(
+        "settings.html",
+        {
+            "request": request,
+            "settings": settings.dict(),
+            "validation_message": validation_message,
+            "validation_error": validation_error,
+            "models": models,
+            "jellyfin_users": users,
+            "log_excerpt": log_excerpt,
+        },
+    )
+
+
+@router.post("/api/test/lastfm", response_model=LastfmTestResponse, tags=["Testing"])
+async def test_lastfm(payload: LastfmTestRequest) -> LastfmTestResponse:
+    """Validate a Last.fm API key by performing a simple artist search."""
+    key = payload.key.strip()
+
+    try:
+        async with httpx.AsyncClient() as client:
+            r = await client.get(
+                "https://ws.audioscrobbler.com/2.0/",
+                params={
+                    "method": "artist.search",
+                    "artist": "radiohead",
+                    "api_key": key,
+                    "format": "json",
+                },
+            )
+
+        json_data = r.json()
+        return LastfmTestResponse(
+            success="error" not in json_data,
+            status=r.status_code,
+            body=json_data,
+        )
+    except httpx.HTTPError as exc:
+        logger.error("HTTP error during Last.fm API test: %s", str(exc))
+        return LastfmTestResponse(
+            success=False,
+            error="An internal error occurred while testing the Last.fm API.",
+        )
+
+
+@router.post(
+    "/api/test/jellyfin", response_model=JellyfinTestResponse, tags=["Testing"]
+)
+async def test_jellyfin(payload: JellyfinTestRequest) -> JellyfinTestResponse:
+    """Verify the provided Jellyfin URL and API key."""
+    url = payload.url.rstrip("/")
+    key = payload.key
+
+    try:
+        headers = {
+            "X-Emby-Token": key,
+            "Accept": "application/json",
+            "User-Agent": "PlaylistPilotTest/1.0",
+        }
+        async with httpx.AsyncClient() as client:
+            r = await client.get(f"{url}/System/Info", headers=headers)
+        logger.debug("Jellyfin Test: %s", r.text)
+
+        json_data = r.json()
+        valid = r.status_code == 200 and any(k.lower() == "version" for k in json_data)
+        return JellyfinTestResponse(success=valid, status=r.status_code, data=json_data)
+    except httpx.HTTPError as exc:
+        logger.error("HTTP error during Jellyfin API test: %s", str(exc))
+        return JellyfinTestResponse(
+            success=False,
+            error="An internal error occurred while testing the Jellyfin API.",
+        )
+
+
+@router.post("/api/test/openai", response_model=OpenAITestResponse, tags=["Testing"])
+async def test_openai(payload: OpenAITestRequest) -> OpenAITestResponse:
+    """Check if the OpenAI API key is valid by listing available models."""
+    key = payload.key
+    try:
+
+        def _list_models():
+            client = openai.OpenAI(api_key=key)
+            return client.models.list()
+
+        models = await asyncio.to_thread(_list_models)
+        valid = any(m.id.startswith("gpt") for m in models.data)
+        return OpenAITestResponse(success=valid)
+    except openai.OpenAIError as exc:
+        logger.error("OpenAI test error: %s", str(exc))
+        return OpenAITestResponse(
+            success=False,
+            error="An internal error has occurred. Please try again later.",
+        )
+
+
+@router.post(
+    "/api/test/getsongbpm",
+    response_model=GetSongBPMTestResponse,
+    tags=["Testing"],
+)
+async def test_getsongbpm(payload: GetSongBPMTestRequest) -> GetSongBPMTestResponse:
+    """Check if the GetSongBPM API key is valid by performing a sample query."""
+    key = payload.key
+    lookup = quote_plus("song:creep artist:radiohead")
+    url = f"{settings.getsongbpm_base_url}?api_key={key}&type=both&lookup={lookup}"
+    try:
+
+        def _fetch():
+            return cloudscraper.create_scraper(browser="chrome").get(
+                url,
+                headers=settings.getsongbpm_headers,
+                timeout=settings.http_timeout_short,
+            )
+
+        r = await asyncio.to_thread(_fetch)
+
+        try:
+            json_data = r.json()
+        except ValueError as exc:  # json.JSONDecodeError inherits from ValueError
+            logger.error("JSON decode error during GetSongBPM API test: %s", str(exc))
+            return GetSongBPMTestResponse(
+                success=False,
+                status=r.status_code,
+                error="Invalid JSON response from GetSongBPM.",
+            )
+        valid = r.status_code == 200 and "search" in json_data
+        return GetSongBPMTestResponse(
+            success=valid, status=r.status_code, data=json_data
+        )
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        logger.error("HTTP error during GetSongBPM API test: %s", str(exc))
+        return GetSongBPMTestResponse(
+            success=False,
+            error="An internal error occurred while testing the GetSongBPM API.",
+        )
+
+
+@router.post(
+    "/api/verify-entry",
+    response_model=VerifyEntryResponse,
+    tags=["Jellyfin"],
+)
+async def verify_playlist_entry(payload: VerifyEntryRequest) -> VerifyEntryResponse:
+    """Confirm that a playlist contains the specified entry ID."""
+    playlist_id = payload.playlist_id
+    entry_id = payload.entry_id
+
+    if not playlist_id or not entry_id:
+        return VerifyEntryResponse(
+            success=False, error="playlist_id and entry_id are required"
+        )
+
+    tracks = await fetch_tracks_for_playlist_id(playlist_id)
+    match = next((t for t in tracks if t.get("PlaylistItemId") == entry_id), None)
+
+    if match:
+        return VerifyEntryResponse(success=True, track=match)
+
+    return VerifyEntryResponse(success=False, error="Entry not found in playlist")

--- a/main.py
+++ b/main.py
@@ -23,7 +23,7 @@ from logging.handlers import RotatingFileHandler
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 
-from api.routes import router as main_router
+from api.routes import router
 from config import settings
 from core.constants import BASE_DIR, LOG_FILE
 from utils.http_client import aclose_http_clients
@@ -55,7 +55,7 @@ except ValueError as e:
 # FastAPI App Setup
 app = FastAPI(title="Playlist Pilot")
 # Include all route handlers
-app.include_router(main_router)
+app.include_router(router)
 # Serve static files (CSS, JS, etc.)
 app.mount("/static", StaticFiles(directory=str(BASE_DIR / "static")), name="static")
 

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -13,7 +13,7 @@ from starlette.datastructures import UploadFile
 
 def _extract_health_check():
     """Load the ``health_check`` coroutine from ``api.routes`` without importing."""
-    src = Path("api/routes.py").read_text(encoding="utf-8")
+    src = Path("api/routes/monitoring_routes.py").read_text(encoding="utf-8")
     tree = ast.parse(src)
     func = next(
         n
@@ -38,7 +38,7 @@ def test_health_check():
 
 def _extract_export_m3u():
     """Return the ``export_m3u`` coroutine without side effects."""
-    src = Path("api/routes.py").read_text(encoding="utf-8")
+    src = Path("api/routes/analysis_routes.py").read_text(encoding="utf-8")
     tree = ast.parse(src)
     func = next(
         n
@@ -64,7 +64,7 @@ def _extract_export_m3u():
 
 def _extract_import_m3u_file():
     """Return ``import_m3u_file`` coroutine without importing ``api.routes``."""
-    src = Path("api/routes.py").read_text(encoding="utf-8")
+    src = Path("api/routes/analysis_routes.py").read_text(encoding="utf-8")
     tree = ast.parse(src)
     func = next(
         n


### PR DESCRIPTION
## Summary
- Split monolithic routes into `analysis_routes`, `settings_routes`, and `monitoring_routes`
- Provide combined router via `api.routes` package and update FastAPI app to use it
- Adjust tests to import helpers from new modules

## Testing
- `black .`
- `pylint core api services utils`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68962aac626883329c71f5f7141c077b