### PR TITLE
chore: suppress requests type warning

### DIFF
--- a/services/getsongbpm.py
+++ b/services/getsongbpm.py
@@ -5,7 +5,7 @@ from urllib.parse import quote_plus
 from typing import Optional, Dict
 
 import json
-import requests
+import requests  # type: ignore[import-untyped]
 import cloudscraper
 
 from utils.cache_manager import bpm_cache, CACHE_TTLS


### PR DESCRIPTION
## Summary
- silence mypy's missing requests stubs in GetSongBPM service

## Testing
- `python -m black .`
- `python -m pylint core api services utils`
- `python -m pytest`
- `python -m mypy services/getsongbpm.py --ignore-missing-imports`


------
https://chatgpt.com/codex/tasks/task_e_6896360d4e2883328b633fcf2d7c935a