### PR TITLE
Display integration failure counts and configurable threshold

### DIFF
--- a/api/routes/settings_routes.py
+++ b/api/routes/settings_routes.py
@@ -98,6 +98,7 @@ async def update_settings(
     settings.lyrics_weight = form_data.lyrics_weight
     settings.bpm_weight = form_data.bpm_weight
     settings.tags_weight = form_data.tags_weight
+    settings.integration_failure_limit = form_data.integration_failure_limit
 
     try:
         settings.validate_settings()

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -37,6 +37,11 @@
     </div>
   {% endif %}
 
+  <div id="integration-failure-wrapper" class="mb-6 p-4 border border-gray-200 dark:border-gray-600 rounded">
+    <h2 class="text-lg font-semibold mb-2">Integration Failures</h2>
+    <ul id="integration-failure-list" class="list-disc pl-5 text-sm text-gray-700 dark:text-gray-300"></ul>
+  </div>
+
   <form method="post" class="space-y-6 bg-white dark:bg-gray-700 p-6 rounded shadow flex flex-col gap-4 w-full">
 
     <div class="grid gap-6 md:grid-cols-2 w-full">
@@ -235,6 +240,15 @@
             <small class="text-gray-300">Relative weight given to tag matches.</small>
           </div>
         </div>
+
+        <h3 class="text-lg font-semibold">Monitoring</h3>
+        <div class="grid gap-4 md:grid-cols-2">
+          <div class="space-y-2">
+            <label for="INTEGRATION_FAILURE_LIMIT" class="block font-semibold">Integration Failure Threshold</label>
+            <input type="number" id="INTEGRATION_FAILURE_LIMIT" name="integration_failure_limit" value="{{ settings.integration_failure_limit }}" class="w-full p-2 border border-gray-300 rounded dark:bg-gray-300 dark:text-black focus:ring-2 focus:ring-blue-500">
+            <small class="text-gray-300">Consecutive failures before warnings are logged.</small>
+          </div>
+        </div>
       </div>
     </details>
 
@@ -251,6 +265,38 @@
   {% endif %}
 
   <script>
+    const failureLimit = {{ settings.integration_failure_limit }};
+    fetch("/api/integration-failures")
+      .then(res => res.json())
+      .then(data => {
+        const list = document.getElementById("integration-failure-list");
+        if (!list) return;
+        const entries = Object.entries(data.failures || {});
+        if (entries.length === 0) {
+          const li = document.createElement("li");
+          li.textContent = "No failures recorded";
+          list.appendChild(li);
+          return;
+        }
+        entries.forEach(([service, count]) => {
+          const li = document.createElement("li");
+          li.textContent = `${service}: ${count}`;
+          if (count >= failureLimit) {
+            li.className = "text-red-600 font-semibold";
+          }
+          list.appendChild(li);
+        });
+      })
+      .catch(() => {
+        const list = document.getElementById("integration-failure-list");
+        if (list) {
+          const li = document.createElement("li");
+          li.textContent = "Failed to load failure counts";
+          li.className = "text-red-600";
+          list.appendChild(li);
+        }
+      });
+
     window.updateStatus = function(id, result, message) {
       const el = document.getElementById(id);
       if (!el) return;

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -43,3 +43,12 @@ def test_as_form_lyrics_enabled_default():
 
     assert isinstance(param.default, Form)
     assert param.default.default is True
+
+
+def test_integration_failure_limit_default():
+    """integration_failure_limit should have a default of 3."""
+    sig = inspect.signature(SettingsForm.as_form)
+    param = sig.parameters["integration_failure_limit"]
+
+    assert isinstance(param.default, Form)
+    assert param.default.default == 3


### PR DESCRIPTION
## Summary
- Show per-service failure counts on the settings page and highlight when the limit is exceeded
- Allow configuring the integration failure threshold via SettingsForm
- Persist new threshold and test its default value

## Testing
- `black .`
- `pylint core api services utils`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68963ce376b883329bb9df9d1c6f1d75