### PR TITLE
refactor: remove redundant AnalysisExportRequest import

### DIFF
--- a/api/routes/analysis_routes.py
+++ b/api/routes/analysis_routes.py
@@ -636,8 +636,6 @@ async def import_m3u_file(
 @router.post("/analyze/export-m3u", tags=["Exports"])
 async def export_m3u(payload: Request):
     """Generate an M3U file from analysis results for download."""
-    from api.schemas import AnalysisExportRequest
-
     data = await payload.json()
     model = AnalysisExportRequest.model_validate(data)
     name = model.name

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -9,6 +9,7 @@ import types
 import pytest
 from fastapi import HTTPException
 from starlette.datastructures import UploadFile
+from api.schemas import AnalysisExportRequest
 
 
 def _extract_health_check():
@@ -57,6 +58,7 @@ def _extract_export_m3u():
         "tempfile": __import__("tempfile"),
         "Path": Path,
         "Request": object,
+        "AnalysisExportRequest": AnalysisExportRequest,
     }
     exec(compile(module, filename="<export_m3u>", mode="exec"), ns)
     return ns["export_m3u"]


### PR DESCRIPTION
## Summary
- drop in-function AnalysisExportRequest import in analysis routes
- update API route tests to provide AnalysisExportRequest

## Testing
- `black api/routes/analysis_routes.py tests/test_api_routes.py`
- `pylint core api services utils`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689642b7e4708332816a6a91fdd191ea