### PR TITLE
Add unit tests for Spotify and Apple Music services

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ pylint
 black
 mypy
 types-requests
+respx

--- a/services/apple_music.py
+++ b/services/apple_music.py
@@ -1,0 +1,68 @@
+"""Apple Music integration for metadata lookup."""
+
+from __future__ import annotations
+
+import logging
+import json
+from typing import Any
+
+import httpx
+
+from config import settings
+from utils.http_client import get_http_client
+
+logger = logging.getLogger("playlist-pilot")
+
+_access_token: str | None = None
+
+
+async def _get_developer_token() -> str | None:
+    """Return a cached Apple Music developer token."""
+    global _access_token  # pylint: disable=global-statement
+    if _access_token:
+        return _access_token
+    client_id = getattr(settings, "apple_client_id", "")
+    client_secret = getattr(settings, "apple_client_secret", "")
+    if not client_id or not client_secret:
+        logger.info("[Apple Music] credentials not configured; skipping token request")
+        return None
+    try:
+        client = get_http_client(short=True)
+        resp = await client.post(
+            "https://apple.music.com/api/token",
+            data={"grant_type": "client_credentials"},
+            auth=(client_id, client_secret),
+        )
+        resp.raise_for_status()
+        _access_token = resp.json().get("access_token")
+        return _access_token
+    except (httpx.HTTPError, json.JSONDecodeError) as exc:
+        logger.warning("Apple Music token fetch failed: %s", exc)
+        return None
+
+
+async def fetch_apple_music_metadata(title: str, artist: str) -> dict[str, Any] | None:
+    """Search Apple Music for basic metadata about a track."""
+    token = await _get_developer_token()
+    if not token:
+        return None
+    try:
+        client = get_http_client(short=True)
+        resp = await client.get(
+            "https://api.music.apple.com/v1/catalog/us/search",
+            params={"term": f"{title} {artist}", "types": "songs", "limit": 1},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        resp.raise_for_status()
+        items = resp.json().get("results", {}).get("songs", {}).get("data", [])
+        if not items:
+            return None
+        track = items[0].get("attributes", {})
+        return {
+            "album": track.get("albumName"),
+            "year": track.get("releaseDate", "")[:4],
+            "duration_ms": track.get("durationInMillis"),
+        }
+    except (httpx.HTTPError, json.JSONDecodeError) as exc:
+        logger.warning("Apple Music lookup failed for %s - %s: %s", title, artist, exc)
+        return None

--- a/tests/test_apple_music.py
+++ b/tests/test_apple_music.py
@@ -1,0 +1,66 @@
+"""Unit tests for the Apple Music service module."""
+
+import asyncio
+import respx
+
+from config import settings
+from services import apple_music
+
+
+def test_get_developer_token(monkeypatch):
+    """Apple Music token retrieval caches tokens."""
+    monkeypatch.setitem(settings.__dict__, "apple_client_id", "id")
+    monkeypatch.setitem(settings.__dict__, "apple_client_secret", "secret")
+    apple_music._access_token = None
+
+    async def main():
+        with respx.mock(assert_all_called=True) as mock:
+            mock.post("https://apple.music.com/api/token").respond(
+                200, json={"access_token": "token"}
+            )
+            token1 = await apple_music._get_developer_token()
+            token2 = await apple_music._get_developer_token()
+            assert token1 == token2 == "token"
+            assert mock.calls.call_count == 1
+
+    asyncio.run(main())
+    asyncio.set_event_loop(asyncio.new_event_loop())
+
+
+def test_fetch_apple_music_metadata(monkeypatch):
+    """Apple Music metadata is parsed correctly."""
+
+    async def fake_token():  # pylint: disable=unused-argument
+        return "token"
+
+    monkeypatch.setattr(apple_music, "_get_developer_token", fake_token)
+
+    async def main():
+        with respx.mock(assert_all_called=True) as mock:
+            mock.get("https://api.music.apple.com/v1/catalog/us/search").respond(
+                200,
+                json={
+                    "results": {
+                        "songs": {
+                            "data": [
+                                {
+                                    "attributes": {
+                                        "albumName": "Album",
+                                        "releaseDate": "2020-05-10",
+                                        "durationInMillis": 250000,
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                },
+            )
+            metadata = await apple_music.fetch_apple_music_metadata("Song", "Artist")
+            assert metadata == {
+                "album": "Album",
+                "year": "2020",
+                "duration_ms": 250000,
+            }
+
+    asyncio.run(main())
+    asyncio.set_event_loop(asyncio.new_event_loop())

--- a/tests/test_spotify_service.py
+++ b/tests/test_spotify_service.py
@@ -1,0 +1,65 @@
+"""Unit tests for the Spotify service module."""
+
+import asyncio
+
+import respx
+
+from config import settings
+from services import spotify
+
+
+def test_get_access_token(monkeypatch):
+    """Spotify access token is fetched and cached."""
+    monkeypatch.setattr(settings, "spotify_client_id", "id")
+    monkeypatch.setattr(settings, "spotify_client_secret", "secret")
+    spotify._access_token = None
+
+    async def main():
+        with respx.mock(assert_all_called=True) as mock:
+            mock.post("https://accounts.spotify.com/api/token").respond(
+                200, json={"access_token": "token"}
+            )
+            token1 = await spotify._get_access_token()
+            token2 = await spotify._get_access_token()
+            assert token1 == token2 == "token"
+            assert mock.calls.call_count == 1
+
+    asyncio.run(main())
+    asyncio.set_event_loop(asyncio.new_event_loop())
+
+
+def test_fetch_spotify_metadata(monkeypatch):
+    """Spotify metadata is parsed correctly."""
+
+    async def fake_token():  # pylint: disable=unused-argument
+        return "token"
+
+    monkeypatch.setattr(spotify, "_get_access_token", fake_token)
+
+    async def main():
+        with respx.mock(assert_all_called=True) as mock:
+            mock.get("https://api.spotify.com/v1/search").respond(
+                200,
+                json={
+                    "tracks": {
+                        "items": [
+                            {
+                                "album": {
+                                    "name": "Album",
+                                    "release_date": "2011-09-09",
+                                },
+                                "duration_ms": 123000,
+                            }
+                        ]
+                    }
+                },
+            )
+            metadata = await spotify.fetch_spotify_metadata("Song", "Artist")
+            assert metadata == {
+                "album": "Album",
+                "year": "2011",
+                "duration_ms": 123000,
+            }
+
+    asyncio.run(main())
+    asyncio.set_event_loop(asyncio.new_event_loop())


### PR DESCRIPTION
## Summary
- add Apple Music service with token caching and metadata lookup
- add respx-based unit tests for Spotify and Apple Music services
- include respx in dev requirements

## Testing
- `pylint core api services utils`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896427059348332b8d3446343165a8c