### PR TITLE
Add caching for Spotify and Apple Music metadata

### DIFF
--- a/config.py
+++ b/config.py
@@ -76,6 +76,8 @@ class AppSettings(BaseModel):
         "bpm": 60 * 60 * 24 * 30,
         "jellyfin_tracks": 60 * 60 * 24,
         "full_library": 60 * 60 * 24,
+        "spotify": 60 * 60 * 24,
+        "apple_music": 60 * 60 * 24,
     }
     getsongbpm_base_url: str = "https://api.getsongbpm.com/search/"
     getsongbpm_headers: dict[str, str] = {

--- a/core/playlist.py
+++ b/core/playlist.py
@@ -340,7 +340,11 @@ async def enrich_track(parsed: Track | dict) -> EnrichedTrack:
                 duration_ms = spotify_meta.get("duration_ms")
                 if duration_ms:
                     parsed.RunTimeTicks = int(duration_ms * 10_000)
-        if settings.apple_client_id and settings.apple_client_secret:
+        if (
+            (not parsed.album or not parsed.year or not parsed.RunTimeTicks)
+            and settings.apple_client_id
+            and settings.apple_client_secret
+        ):
             apple_meta = (
                 await fetch_applemusic_metadata(parsed.title, parsed.artist) or {}
             )

--- a/tests/test_cross_service_metadata.py
+++ b/tests/test_cross_service_metadata.py
@@ -1,0 +1,137 @@
+import asyncio
+import respx
+
+from config import settings
+from services import spotify, applemusic
+from core import playlist
+
+
+class DummyCache(dict):
+    def get(self, key, default=None):
+        return super().get(key, default)
+
+    def set(self, key, value, expire=None):
+        self[key] = value
+
+
+def test_spotify_metadata_caching(monkeypatch):
+    monkeypatch.setattr(spotify, "spotify_cache", DummyCache())
+
+    async def fake_token():
+        return "token"
+
+    monkeypatch.setattr(spotify, "_get_access_token", fake_token)
+
+    async def main():
+        with respx.mock(assert_all_called=True) as mock:
+            mock.get("https://api.spotify.com/v1/search").respond(
+                200,
+                json={
+                    "tracks": {
+                        "items": [
+                            {
+                                "album": {
+                                    "name": "Album",
+                                    "release_date": "2000-01-01",
+                                },
+                                "duration_ms": 123000,
+                            }
+                        ]
+                    }
+                },
+            )
+            meta1 = await spotify.fetch_spotify_metadata("Song", "Artist")
+            meta2 = await spotify.fetch_spotify_metadata("Song", "Artist")
+            assert (
+                meta1
+                == meta2
+                == {
+                    "album": "Album",
+                    "year": "2000",
+                    "duration_ms": 123000,
+                }
+            )
+            assert len(spotify.spotify_cache) == 1
+            assert mock.calls.call_count == 1
+
+    asyncio.run(main())
+    asyncio.set_event_loop(asyncio.new_event_loop())
+
+
+def test_apple_music_metadata_caching(monkeypatch):
+    monkeypatch.setattr(applemusic, "apple_music_cache", DummyCache())
+
+    async def fake_token():
+        return "token"
+
+    monkeypatch.setattr(applemusic, "_get_developer_token", fake_token)
+
+    async def main():
+        with respx.mock(assert_all_called=True) as mock:
+            mock.get("https://api.music.apple.com/v1/catalog/us/search").respond(
+                200,
+                json={
+                    "results": {
+                        "songs": {
+                            "data": [
+                                {
+                                    "attributes": {
+                                        "albumName": "Album",
+                                        "releaseDate": "2020-05-10",
+                                        "durationInMillis": 250000,
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                },
+            )
+            meta1 = await applemusic.fetch_applemusic_metadata("Song", "Artist")
+            meta2 = await applemusic.fetch_applemusic_metadata("Song", "Artist")
+            assert (
+                meta1
+                == meta2
+                == {
+                    "album": "Album",
+                    "year": "2020",
+                    "duration_ms": 250000,
+                }
+            )
+            assert len(applemusic.apple_music_cache) == 1
+            assert mock.calls.call_count == 1
+
+    asyncio.run(main())
+    asyncio.set_event_loop(asyncio.new_event_loop())
+
+
+def test_enrich_track_falls_back_to_apple_music(monkeypatch):
+    async def fake_spotify(title, artist):
+        return None
+
+    async def fake_apple(title, artist):
+        return {"album": "Apple Album", "year": "1999", "duration_ms": 123000}
+
+    async def fake_lastfm_data(title, artist):
+        return {"tags": [], "listeners": 0, "album": ""}
+
+    monkeypatch.setattr(settings, "spotify_client_id", "id")
+    monkeypatch.setattr(settings, "spotify_client_secret", "secret")
+    monkeypatch.setattr(settings, "apple_client_id", "id")
+    monkeypatch.setattr(settings, "apple_client_secret", "secret")
+    monkeypatch.setattr(playlist, "fetch_spotify_metadata", fake_spotify)
+    monkeypatch.setattr(playlist, "fetch_applemusic_metadata", fake_apple)
+    monkeypatch.setattr(playlist, "_get_lastfm_data", fake_lastfm_data)
+
+    track = {
+        "title": "Song",
+        "artist": "Artist",
+        "album": "",
+        "year": "",
+        "RunTimeTicks": 0,
+        "Genres": [],
+    }
+    enriched = asyncio.run(playlist.enrich_track(track))
+    asyncio.set_event_loop(asyncio.new_event_loop())
+    assert enriched.album == "Apple Album"
+    assert enriched.FinalYear == "1999"
+    assert enriched.RunTimeTicks == 123000 * 10000

--- a/utils/cache_manager.py
+++ b/utils/cache_manager.py
@@ -7,6 +7,8 @@ Defines named persistent caches using diskcache for various subsystems:
 - lastfm_cache: Last.fm track existence flags
 - playlist_cache: Jellyfin playlists per user
 - LASTFM_POP_CACHE: listener count from Last.fm
+- spotify_cache: Spotify track metadata
+- apple_music_cache: Apple Music track metadata
 
 All caches are file-backed and located in the `cache/` directory.
 """
@@ -44,6 +46,12 @@ bpm_cache = Cache(BASE_CACHE / "bpm")
 
 # Caches results of a full Jellyfin library scan
 library_cache = Cache(BASE_CACHE / "full_library")
+
+# Cache Spotify metadata lookups
+spotify_cache = Cache(BASE_CACHE / "spotify")
+
+# Cache Apple Music metadata lookups
+apple_music_cache = Cache(BASE_CACHE / "apple_music")
 
 
 # TTL configuration (in seconds) for each named cache


### PR DESCRIPTION
## Summary
- cache Spotify and Apple Music metadata in dedicated diskcache stores
- fallback to Apple Music metadata when Spotify data is unavailable
- test cached lookups and cross-service enrichment

## Testing
- `black .`
- `pylint core api services utils`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68964f8551dc833291e5ff21a4976120