### PR TITLE
Version API endpoints and document OpenAPI schema

### DIFF
--- a/Docs/api_reference.md
+++ b/Docs/api_reference.md
@@ -1,31 +1,295 @@
 # API Reference
 
-The table below summarises the main endpoints exposed by Playlist Pilot. All endpoints return JSON or HTML depending on the route.
+All programmatic endpoints are versioned under `/api/v1`.
 
 | Method | Path | Description |
 |-------|------|-------------|
-| GET | `/` | Home page showing Jellyfin playlists and history |
-| GET | `/analyze` | Choose a playlist for analysis |
-| POST | `/analyze/result` | Display analysis results |
-| POST | `/analyze/export-m3u` | Export analyzed tracks as M3U |
-| POST | `/suggest-playlist` | Suggest a playlist from analysis results |
-| POST | `/suggest-order` | Get a recommended track order |
-| GET | `/compare` | Display comparison form |
-| POST | `/compare` | Compare two playlists |
-| GET | `/history` | View past GPT suggestions |
-| POST | `/history/delete` | Delete a history entry |
-| GET | `/history/export` | Export a history entry as `.m3u` |
-| POST | `/import_m3u` | Import an `.m3u` file |
-| POST | `/export/jellyfin` | Create a Jellyfin playlist |
-| POST | `/export/track-metadata` | Update Jellyfin track metadata |
-| GET | `/settings` | View current configuration |
-| POST | `/settings` | Update settings |
-| POST | `/api/test/lastfm` | Verify Last.fm connectivity |
-| POST | `/api/test/jellyfin` | Verify Jellyfin connectivity |
-| POST | `/api/test/openai` | Verify OpenAI connectivity |
-| POST | `/api/test/getsongbpm` | Verify GetSongBPM connectivity |
-| POST | `/api/verify-entry` | Verify a playlist entry ID |
-| GET | `/api/integration-failures` | Current integration failure counters |
-| GET | `/health` | Simple health check |
+| GET | `/api/v1/health` | Simple health check |
+| GET | `/api/v1/integration-failures` | Current integration failure counters |
+| POST | `/api/v1/test/lastfm` | Verify Last.fm connectivity |
+| POST | `/api/v1/test/jellyfin` | Verify Jellyfin connectivity |
+| POST | `/api/v1/test/openai` | Verify OpenAI connectivity |
+| POST | `/api/v1/test/getsongbpm` | Verify GetSongBPM connectivity |
+| POST | `/api/v1/verify-entry` | Verify a playlist entry ID |
 
-Return codes generally follow HTTP conventions: 200 for success, 4xx for invalid input and 5xx for unexpected errors.
+## Example Requests
+
+### Health Check
+```bash
+curl http://localhost:8000/api/v1/health
+```
+
+### Verify Jellyfin
+```bash
+curl -X POST http://localhost:8000/api/v1/test/jellyfin \
+  -H 'Content-Type: application/json' \
+  -d '{"url":"http://jellyfin.local","key":"API_KEY"}'
+```
+
+## Authentication
+
+Endpoints do not require authentication by default. Use a reverse proxy or custom middleware if your deployment needs protection.
+
+## OpenAPI schema
+
+```json
+{
+  "openapi": "3.1.0",
+  "paths": {
+    "/api/v1/test/lastfm": {
+      "post": {
+        "tags": [
+          "Testing"
+        ],
+        "summary": "Test Lastfm",
+        "description": "Validate a Last.fm API key by performing a simple artist search.",
+        "operationId": "test_lastfm_api_v1_test_lastfm_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LastfmTestRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LastfmTestResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/test/jellyfin": {
+      "post": {
+        "tags": [
+          "Testing"
+        ],
+        "summary": "Test Jellyfin",
+        "description": "Verify the provided Jellyfin URL and API key.",
+        "operationId": "test_jellyfin_api_v1_test_jellyfin_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JellyfinTestRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JellyfinTestResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/test/openai": {
+      "post": {
+        "tags": [
+          "Testing"
+        ],
+        "summary": "Test Openai",
+        "description": "Check if the OpenAI API key is valid by listing available models.",
+        "operationId": "test_openai_api_v1_test_openai_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OpenAITestRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpenAITestResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/test/getsongbpm": {
+      "post": {
+        "tags": [
+          "Testing"
+        ],
+        "summary": "Test Getsongbpm",
+        "description": "Check if the GetSongBPM API key is valid by performing a sample query.",
+        "operationId": "test_getsongbpm_api_v1_test_getsongbpm_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GetSongBPMTestRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetSongBPMTestResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/verify-entry": {
+      "post": {
+        "tags": [
+          "Jellyfin"
+        ],
+        "summary": "Verify Playlist Entry",
+        "description": "Confirm that a playlist contains the specified entry ID.",
+        "operationId": "verify_playlist_entry_api_v1_verify_entry_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VerifyEntryRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VerifyEntryResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/health": {
+      "get": {
+        "tags": [
+          "System"
+        ],
+        "summary": "Health Check",
+        "description": "Simple endpoint for container liveness monitoring.",
+        "operationId": "health_check_api_v1_health_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/integration-failures": {
+      "get": {
+        "tags": [
+          "Monitoring"
+        ],
+        "summary": "Integration Failures",
+        "description": "Return current integration failure counters.",
+        "operationId": "integration_failures_api_v1_integration_failures_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IntegrationFailuresResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```

--- a/api/routes/__init__.py
+++ b/api/routes/__init__.py
@@ -3,12 +3,18 @@
 from fastapi import APIRouter
 
 from .analysis_routes import router as analysis_router
-from .settings_routes import router as settings_router
+from .settings_routes import (
+    router as settings_router,
+    api_router as settings_api_router,
+)
 from .monitoring_routes import router as monitoring_router
 
 router = APIRouter()
 router.include_router(analysis_router)
 router.include_router(settings_router)
-router.include_router(monitoring_router)
 
-__all__ = ["router"]
+api_router = APIRouter()
+api_router.include_router(settings_api_router)
+api_router.include_router(monitoring_router)
+
+__all__ = ["router", "api_router"]

--- a/api/routes/monitoring_routes.py
+++ b/api/routes/monitoring_routes.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter
 from api.schemas import HealthResponse, IntegrationFailuresResponse
 from utils.integration_watchdog import get_failure_counts
 
-router = APIRouter()
+router = APIRouter(prefix="/api/v1")
 
 
 @router.get("/health", response_model=HealthResponse, tags=["System"])
@@ -15,10 +15,13 @@ async def health_check():
 
 
 @router.get(
-    "/api/integration-failures",
+    "/integration-failures",
     response_model=IntegrationFailuresResponse,
     tags=["Monitoring"],
 )
 async def integration_failures() -> IntegrationFailuresResponse:
     """Return current integration failure counters."""
     return IntegrationFailuresResponse(failures=get_failure_counts())
+
+
+__all__ = ["router"]

--- a/api/routes/settings_routes.py
+++ b/api/routes/settings_routes.py
@@ -32,6 +32,7 @@ from api.schemas import (
 logger = logging.getLogger("playlist-pilot")
 
 router = APIRouter()
+api_router = APIRouter(prefix="/api/v1")
 
 
 @router.get("/settings", response_class=HTMLResponse, tags=["Settings"])
@@ -122,7 +123,7 @@ async def update_settings(
     )
 
 
-@router.post("/api/test/lastfm", response_model=LastfmTestResponse, tags=["Testing"])
+@api_router.post("/test/lastfm", response_model=LastfmTestResponse, tags=["Testing"])
 async def test_lastfm(payload: LastfmTestRequest) -> LastfmTestResponse:
     """Validate a Last.fm API key by performing a simple artist search."""
     key = payload.key.strip()
@@ -153,8 +154,8 @@ async def test_lastfm(payload: LastfmTestRequest) -> LastfmTestResponse:
         )
 
 
-@router.post(
-    "/api/test/jellyfin", response_model=JellyfinTestResponse, tags=["Testing"]
+@api_router.post(
+    "/test/jellyfin", response_model=JellyfinTestResponse, tags=["Testing"]
 )
 async def test_jellyfin(payload: JellyfinTestRequest) -> JellyfinTestResponse:
     """Verify the provided Jellyfin URL and API key."""
@@ -182,7 +183,7 @@ async def test_jellyfin(payload: JellyfinTestRequest) -> JellyfinTestResponse:
         )
 
 
-@router.post("/api/test/openai", response_model=OpenAITestResponse, tags=["Testing"])
+@api_router.post("/test/openai", response_model=OpenAITestResponse, tags=["Testing"])
 async def test_openai(payload: OpenAITestRequest) -> OpenAITestResponse:
     """Check if the OpenAI API key is valid by listing available models."""
     key = payload.key
@@ -203,8 +204,8 @@ async def test_openai(payload: OpenAITestRequest) -> OpenAITestResponse:
         )
 
 
-@router.post(
-    "/api/test/getsongbpm",
+@api_router.post(
+    "/test/getsongbpm",
     response_model=GetSongBPMTestResponse,
     tags=["Testing"],
 )
@@ -245,8 +246,8 @@ async def test_getsongbpm(payload: GetSongBPMTestRequest) -> GetSongBPMTestRespo
         )
 
 
-@router.post(
-    "/api/verify-entry",
+@api_router.post(
+    "/verify-entry",
     response_model=VerifyEntryResponse,
     tags=["Jellyfin"],
 )
@@ -267,3 +268,6 @@ async def verify_playlist_entry(payload: VerifyEntryRequest) -> VerifyEntryRespo
         return VerifyEntryResponse(success=True, track=match)
 
     return VerifyEntryResponse(success=False, error="Entry not found in playlist")
+
+
+__all__ = ["router", "api_router"]

--- a/main.py
+++ b/main.py
@@ -23,7 +23,7 @@ from logging.handlers import RotatingFileHandler
 from fastapi import FastAPI, Request
 from fastapi.staticfiles import StaticFiles
 
-from api.routes import router
+from api.routes import router, api_router
 from config import settings
 from core.constants import BASE_DIR, LOG_FILE
 from utils.http_client import aclose_http_clients
@@ -93,6 +93,7 @@ async def add_version_header(request: Request, call_next):
 
 # Include all route handlers
 app.include_router(router)
+app.include_router(api_router)
 # Serve static files (CSS, JS, etc.)
 app.mount("/static", StaticFiles(directory=str(BASE_DIR / "static")), name="static")
 

--- a/tests/test_api_versioning.py
+++ b/tests/test_api_versioning.py
@@ -1,0 +1,22 @@
+"""Integration tests for versioned API endpoints."""
+
+from fastapi.testclient import TestClient
+from main import app
+
+client = TestClient(app)
+
+
+def test_health_endpoint():
+    """The health endpoint should return status ok."""
+    response = client.get("/api/v1/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_integration_failures_endpoint():
+    """Integration failures endpoint should return a failures dictionary."""
+    response = client.get("/api/v1/integration-failures")
+    assert response.status_code == 200
+    data = response.json()
+    assert "failures" in data
+    assert isinstance(data["failures"], dict)


### PR DESCRIPTION
## Summary
- add `/api/v1` router and migrate system and test endpoints
- generate API reference with OpenAPI schema and example client requests
- add integration tests covering versioned endpoints

## Testing
- `pip install -r requirements.txt`
- `pip install pylint black pytest`
- `pip install -r requirements-dev.txt`
- `black .`
- `pylint core api services utils`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896579b32f483328a49a9add6492cc5