### PR TITLE
chore: quiet test lints

### DIFF
--- a/tests/test_applemusic.py
+++ b/tests/test_applemusic.py
@@ -1,5 +1,7 @@
 """Unit tests for the Apple Music service module."""
 
+# pylint: disable=protected-access, duplicate-code
+
 import asyncio
 import respx
 
@@ -33,11 +35,15 @@ def test_fetch_applemusic_metadata(monkeypatch):
     async def fake_token():  # pylint: disable=unused-argument
         return "token"
 
+    applemusic.apple_music_cache.clear()
     monkeypatch.setattr(applemusic, "_get_developer_token", fake_token)
 
     async def main():
         with respx.mock(assert_all_called=True) as mock:
-            mock.get("https://api.music.apple.com/v1/catalog/us/search").respond(
+            mock.get(
+                "https://api.music.apple.com/v1/catalog/us/search",
+                params={"term": "Song Artist", "types": "songs", "limit": 1},
+            ).respond(
                 200,
                 json={
                     "results": {

--- a/tests/test_integration_watchdog.py
+++ b/tests/test_integration_watchdog.py
@@ -1,6 +1,9 @@
+"""Tests for the integration watchdog utilities."""
+
+# pylint: disable=protected-access, duplicate-code
+
 import ast
 import logging
-import asyncio
 from pathlib import Path
 
 from fastapi import FastAPI, APIRouter
@@ -51,7 +54,9 @@ def _extract_integration_failures():
         "IntegrationFailuresResponse": IntegrationFailuresResponse,
         "get_failure_counts": watchdog.get_failure_counts,
     }
-    exec(compile(module, filename="<monitor>", mode="exec"), ns)
+    exec(
+        compile(module, filename="<monitor>", mode="exec"), ns
+    )  # pylint: disable=exec-used
     return ns["integration_failures"]
 
 

--- a/tests/test_spotify.py
+++ b/tests/test_spotify.py
@@ -1,9 +1,12 @@
 """Tests for Spotify metadata fetching and track enrichment."""
 
+# pylint: disable=duplicate-code
+
 import asyncio
 
 from config import settings
 from core import playlist
+from services import spotify
 
 
 def test_fetch_spotify_metadata_without_credentials(monkeypatch):
@@ -11,6 +14,7 @@ def test_fetch_spotify_metadata_without_credentials(monkeypatch):
 
     monkeypatch.setattr(settings, "spotify_client_id", "")
     monkeypatch.setattr(settings, "spotify_client_secret", "")
+    spotify.spotify_cache.clear()
     result = asyncio.run(playlist.fetch_spotify_metadata("Song", "Artist"))
     assert result is None
 

--- a/tests/test_spotify_service.py
+++ b/tests/test_spotify_service.py
@@ -1,5 +1,7 @@
 """Unit tests for the Spotify service module."""
 
+# pylint: disable=protected-access, duplicate-code
+
 import asyncio
 
 import respx
@@ -34,11 +36,19 @@ def test_fetch_spotify_metadata(monkeypatch):
     async def fake_token():  # pylint: disable=unused-argument
         return "token"
 
+    spotify.spotify_cache.clear()
     monkeypatch.setattr(spotify, "_get_access_token", fake_token)
 
     async def main():
         with respx.mock(assert_all_called=True) as mock:
-            mock.get("https://api.spotify.com/v1/search").respond(
+            mock.get(
+                "https://api.spotify.com/v1/search",
+                params={
+                    "q": "track:Song artist:Artist",
+                    "type": "track",
+                    "limit": 1,
+                },
+            ).respond(
                 200,
                 json={
                     "tracks": {


### PR DESCRIPTION
## Summary
- silence pylint warnings in test modules
- clear caches and add query params for respx mocks

## Testing
- `pylint core api services utils`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68965ee697ac8332ad943274196f2912